### PR TITLE
Add SEO metadata, structured data and sitemaps

### DIFF
--- a/app/categorie/[slug]/page.tsx
+++ b/app/categorie/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
 import { getCategoryBySlug, fixtures } from '@/lib/wp'
+import type { Metadata } from 'next'
+import { siteUrl } from '@/lib/utils'
 
 export function generateStaticParams() {
   return fixtures.categories.map((c) => ({ slug: c.slug }))
@@ -9,6 +11,17 @@ export function generateStaticParams() {
 interface Props {
   params: { slug: string }
   searchParams?: { [key: string]: string | string[] | undefined }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { category } = await getCategoryBySlug(params.slug, { page: 1, perPage: 1 })
+  if (!category) return { title: 'Categorie' }
+  const url = `${siteUrl}/categorie/${category.slug}`
+  return {
+    title: category.name,
+    description: `Știri din categoria ${category.name}`,
+    alternates: { canonical: url },
+  }
 }
 
 export default async function CategoryPage({ params, searchParams }: Props) {
@@ -27,6 +40,19 @@ export default async function CategoryPage({ params, searchParams }: Props) {
           posts.map((a) => <ArticleCard key={a.slug} article={a} />)
         )}
       </div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
+              { '@type': 'ListItem', position: 2, name: category.name, item: `${siteUrl}/categorie/${category.slug}` },
+            ],
+          }),
+        }}
+      />
     </div>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,50 @@
 import './globals.css'
 import Link from 'next/link'
 import { ReactNode } from 'react'
+import type { Metadata } from 'next'
+import { siteUrl } from '@/lib/utils'
 
-export const metadata = {
-  title: 'Știri',
-  description: 'Site de știri static',
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: 'Green News România',
+    template: '%s | Green News România',
+  },
+  description: 'Portal de știri din România',
+  openGraph: {
+    title: 'Green News România',
+    description: 'Portal de știri din România',
+    url: siteUrl,
+    siteName: 'Green News România',
+    type: 'website',
+  },
+  alternates: {
+    canonical: siteUrl,
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ro">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Organization',
+              name: 'Green News România',
+              url: siteUrl,
+              logo: `${siteUrl}/logo.png`,
+            }),
+          }}
+        />
+      </head>
       <body className="min-h-screen flex flex-col">
         <header className="border-b">
           <div className="container mx-auto flex items-center justify-between py-4 px-4">
             <Link href="/" className="text-2xl font-bold">
-              Știri
+              Green News România
             </Link>
             <nav className="space-x-4 text-sm">
               <Link href="/despre" className="hover:underline">
@@ -31,7 +61,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         </header>
         <main className="flex-1 container mx-auto px-4 py-6">{children}</main>
         <footer className="border-t py-6 text-center text-sm text-gray-500">
-          © {new Date().getFullYear()} Știri. Toate drepturile rezervate.
+          © {new Date().getFullYear()} Green News România. Toate drepturile rezervate.
         </footer>
       </body>
     </html>

--- a/app/news-sitemap.xml/route.ts
+++ b/app/news-sitemap.xml/route.ts
@@ -1,0 +1,23 @@
+import { getPosts } from '@/lib/wp'
+import { siteUrl } from '@/lib/utils'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const posts = await getPosts({ page: 1, perPage: 100 })
+  const recent = posts.filter(
+    (p) => Date.now() - new Date(p.date).getTime() <= 48 * 60 * 60 * 1000
+  )
+  const items = recent
+    .map(
+      (p) =>
+        `<url><loc>${siteUrl}/stiri/${p.slug}</loc><news:news><news:publication><news:name>Green News România</news:name><news:language>ro</news:language></news:publication><news:publication_date>${p.date}</news:publication_date><news:title>${p.title}</news:title></news:news></url>`
+    )
+    .join('')
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">\n${items}\n</urlset>`
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,12 @@
+import { siteUrl } from '@/lib/utils'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const content = `User-agent: *\nAllow: /\nSitemap: ${siteUrl}/sitemap.xml\nSitemap: ${siteUrl}/news-sitemap.xml`
+  return new Response(content, {
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  })
+}

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,20 @@
+import { getPosts } from '@/lib/wp'
+import { siteUrl } from '@/lib/utils'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const posts = await getPosts({ page: 1, perPage: 100 })
+  const urls = posts
+    .map(
+      (p) =>
+        `<url><loc>${siteUrl}/stiri/${p.slug}</loc><lastmod>${p.modified}</lastmod></url>`
+    )
+    .join('')
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<url><loc>${siteUrl}</loc></url>${urls}\n</urlset>`
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  })
+}

--- a/app/stiri/[slug]/page.tsx
+++ b/app/stiri/[slug]/page.tsx
@@ -3,6 +3,8 @@ import ProseContent from '@/components/ProseContent'
 import ShareBar from '@/components/ShareBar'
 import AdsenseSlot from '@/components/AdsenseSlot'
 import { getPostBySlug, getPosts } from '@/lib/wp'
+import type { Metadata } from 'next'
+import { siteUrl } from '@/lib/utils'
 
 interface Props {
   params: { slug: string }
@@ -11,6 +13,27 @@ interface Props {
 export async function generateStaticParams() {
   const posts = await getPosts({ page: 1, perPage: 100 })
   return posts.map((a) => ({ slug: a.slug }))
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const article = await getPostBySlug(params.slug)
+  if (!article)
+    return {
+      title: 'Articol',
+    }
+  const url = `${siteUrl}/stiri/${article.slug}`
+  return {
+    title: article.title,
+    description: article.excerpt,
+    openGraph: {
+      title: article.title,
+      description: article.excerpt,
+      type: 'article',
+      images: article.image ? [{ url: article.image }] : undefined,
+      url,
+    },
+    alternates: { canonical: url },
+  }
 }
 
 export default async function ArticlePage({ params }: Props) {
@@ -24,6 +47,39 @@ export default async function ArticlePage({ params }: Props) {
       <ProseContent html={article.content} />
       <ShareBar title={article.title} />
       <AdsenseSlot />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: [
+              { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
+              { '@type': 'ListItem', position: 2, name: article.title, item: `${siteUrl}/stiri/${article.slug}` },
+            ],
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'NewsArticle',
+            headline: article.title,
+            image: [article.image],
+            datePublished: article.date,
+            dateModified: article.modified,
+            author: { '@type': 'Person', name: article.author.name },
+            publisher: {
+              '@type': 'Organization',
+              name: 'Green News România',
+              logo: { '@type': 'ImageObject', url: `${siteUrl}/logo.png` },
+            },
+            mainEntityOfPage: { '@type': 'WebPage', '@id': `${siteUrl}/stiri/${article.slug}` },
+          }),
+        }}
+      />
     </article>
   )
 }

--- a/lib/fixtures/posts.json
+++ b/lib/fixtures/posts.json
@@ -7,7 +7,9 @@
     "categories": [{ "slug": "general", "name": "General" }],
     "tags": [{ "slug": "actualitate", "name": "Actualitate" }],
     "author": { "slug": "ion-pop", "name": "Ion Pop" },
-    "image": "https://images.unsplash.com/photo-1522199710521-72d69614c702"
+    "image": "https://images.unsplash.com/photo-1522199710521-72d69614c702",
+    "date": "2025-05-27T08:00:00Z",
+    "modified": "2025-05-27T08:00:00Z"
   },
   {
     "slug": "a-doua-stire",
@@ -17,6 +19,8 @@
     "categories": [{ "slug": "tehnologie", "name": "Tehnologie" }],
     "tags": [{ "slug": "tech", "name": "Tech" }],
     "author": { "slug": "maria-ionescu", "name": "Maria Ionescu" },
-    "image": "https://images.unsplash.com/photo-1504384308090-c894fdcc538d"
+    "image": "https://images.unsplash.com/photo-1504384308090-c894fdcc538d",
+    "date": "2025-05-28T09:00:00Z",
+    "modified": "2025-05-28T09:00:00Z"
   }
 ]

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,5 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: any[]) {
   return twMerge(clsx(inputs))
 }
+
+export const siteUrl = process.env.SITE_URL || 'https://green-news.ro'

--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -11,6 +11,8 @@ export interface Post {
   excerpt: string
   content: string
   image: string
+  date: string
+  modified: string
   categories: Term[]
   tags: Term[]
   author: Author
@@ -39,6 +41,8 @@ function mapPost(node: any): Post {
     excerpt: node.excerpt,
     content: node.content,
     image: node.featuredImage?.node?.sourceUrl || '',
+    date: node.date || '',
+    modified: node.modified || '',
     categories: node.categories?.nodes?.map((c: any) => ({ slug: c.slug, name: c.name })) || [],
     tags: node.tags?.nodes?.map((t: any) => ({ slug: t.slug, name: t.name })) || [],
     author: {
@@ -49,7 +53,7 @@ function mapPost(node: any): Post {
 }
 
 export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Posts($offset: Int!, $size: Int!){\n    posts(where:{offsetPagination:{offset:$offset, size:$size}}){\n      nodes{\n        slug title excerpt content\n        categories{nodes{slug name}}\n        tags{nodes{slug name}}\n        author{node{slug name}}\n        featuredImage{node{sourceUrl}}\n      }\n    }\n  }`
+  const query = `query Posts($offset: Int!, $size: Int!){\n    posts(where:{offsetPagination:{offset:$offset, size:$size}}){\n      nodes{\n        slug title excerpt content date modified\n        categories{nodes{slug name}}\n        tags{nodes{slug name}}\n        author{node{slug name}}\n        featuredImage{node{sourceUrl}}\n      }\n    }\n  }`
   const variables = { offset: (page - 1) * perPage, size: perPage }
   try {
     const data = await fetchGraphQL<any>(query, variables)
@@ -60,7 +64,7 @@ export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perP
 }
 
 export async function getFeaturedPost(): Promise<Post | undefined> {
-  const query = `query Featured{\n    posts(where:{sticky:true}, first:1){nodes{slug title excerpt content categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
+  const query = `query Featured{\n    posts(where:{sticky:true}, first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
   try {
     const data = await fetchGraphQL<any>(query, {})
     const node = data.posts.nodes[0]
@@ -71,7 +75,7 @@ export async function getFeaturedPost(): Promise<Post | undefined> {
 }
 
 export async function getPostBySlug(slug: string): Promise<Post | undefined> {
-  const query = `query PostBySlug($slug: ID!){\n    post(id:$slug, idType:SLUG){\n      slug title excerpt content\n      categories{nodes{slug name}}\n      tags{nodes{slug name}}\n      author{node{slug name}}\n      featuredImage{node{sourceUrl}}\n    }\n  }`
+  const query = `query PostBySlug($slug: ID!){\n    post(id:$slug, idType:SLUG){\n      slug title excerpt content date modified\n      categories{nodes{slug name}}\n      tags{nodes{slug name}}\n      author{node{slug name}}\n      featuredImage{node{sourceUrl}}\n    }\n  }`
   try {
     const data = await fetchGraphQL<any>(query, { slug })
     return data.post ? mapPost(data.post) : undefined
@@ -81,7 +85,7 @@ export async function getPostBySlug(slug: string): Promise<Post | undefined> {
 }
 
 export async function getCategoryBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Category($slug: ID!, $offset: Int!, $size: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
+  const query = `query Category($slug: ID!, $offset: Int!, $size: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
   const variables = { slug, offset: (page - 1) * perPage, size: perPage }
   try {
     const data = await fetchGraphQL<any>(query, variables)
@@ -100,7 +104,7 @@ export async function getCategoryBySlug(slug: string, { page = 1, perPage = 10 }
 }
 
 export async function getTagBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Tag($slug: ID!, $offset: Int!, $size: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
+  const query = `query Tag($slug: ID!, $offset: Int!, $size: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
   const variables = { slug, offset: (page - 1) * perPage, size: perPage }
   try {
     const data = await fetchGraphQL<any>(query, variables)
@@ -119,7 +123,7 @@ export async function getTagBySlug(slug: string, { page = 1, perPage = 10 }: { p
 }
 
 export async function getAuthorBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Author($slug: ID!, $offset: Int!, $size: Int!){\n    user(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content categories{nodes{slug name}} tags{nodes{slug name}} featuredImage{node{sourceUrl}} author{node{slug name}}}}\n    }\n  }`
+  const query = `query Author($slug: ID!, $offset: Int!, $size: Int!){\n    user(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} featuredImage{node{sourceUrl}} author{node{slug name}}}}\n    }\n  }`
   const variables = { slug, offset: (page - 1) * perPage, size: perPage }
   try {
     const data = await fetchGraphQL<any>(query, variables)
@@ -138,7 +142,7 @@ export async function getAuthorBySlug(slug: string, { page = 1, perPage = 10 }: 
 }
 
 export async function searchPosts(term: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Search($term: String!, $offset: Int!, $size: Int!){\n    posts(where:{search:$term, offsetPagination:{offset:$offset, size:$size}}){\n      nodes{slug title excerpt content categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}\n    }\n  }`
+  const query = `query Search($term: String!, $offset: Int!, $size: Int!){\n    posts(where:{search:$term, offsetPagination:{offset:$offset, size:$size}}){\n      nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}\n    }\n  }`
   const variables = { term, offset: (page - 1) * perPage, size: perPage }
   try {
     const data = await fetchGraphQL<any>(query, variables)


### PR DESCRIPTION
## Summary
- add site-wide metadata and organization JSON-LD
- inject per-page SEO metadata and NewsArticle/Breadcrumb JSON-LD
- provide sitemap, news sitemap and robots.txt routes
- remove committed binary logo asset

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint setup prompt)
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ae2cf048332bbca02e31b0c8232