### PR TITLE
Allow dynamic search param pagination

### DIFF
--- a/app/autor/[slug]/page.tsx
+++ b/app/autor/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
-import { getAuthorBySlug, fixtures } from '@/lib/wp'
+import { getAuthorBySlug, fixtures, type Post } from '@/lib/wp'
 
 export function generateStaticParams() {
   return fixtures.authors.map((a) => ({ slug: a.slug }))
@@ -24,7 +24,7 @@ export default async function AuthorPage({ params, searchParams }: Props) {
         {posts.length === 0 ? (
           <p className="text-gray-500">Nu există articole scrise de acest autor.</p>
         ) : (
-          posts.map((a) => <ArticleCard key={a.slug} article={a} />)
+          posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
         )}
       </div>
     </div>

--- a/app/categorie/[slug]/page.tsx
+++ b/app/categorie/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
-import { getCategoryBySlug, fixtures } from '@/lib/wp'
+import { getCategoryBySlug, fixtures, type Post } from '@/lib/wp'
 import type { Metadata } from 'next'
 import { siteUrl } from '@/lib/utils'
 
@@ -37,7 +37,7 @@ export default async function CategoryPage({ params, searchParams }: Props) {
         {posts.length === 0 ? (
           <p className="text-gray-500">Nu există articole în această categorie.</p>
         ) : (
-          posts.map((a) => <ArticleCard key={a.slug} article={a} />)
+          posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
         )}
       </div>
       <script

--- a/app/eticheta/[slug]/page.tsx
+++ b/app/eticheta/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
-import { getTagBySlug, fixtures } from '@/lib/wp'
+import { getTagBySlug, fixtures, type Post } from '@/lib/wp'
 
 export function generateStaticParams() {
   return fixtures.tags.map((t) => ({ slug: t.slug }))
@@ -24,7 +24,7 @@ export default async function TagPage({ params, searchParams }: Props) {
         {posts.length === 0 ? (
           <p className="text-gray-500">Nu există articole pentru această etichetă.</p>
         ) : (
-          posts.map((a) => <ArticleCard key={a.slug} article={a} />)
+          posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
         )}
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ interface Props {
   searchParams?: { [key: string]: string | string[] | undefined }
 }
 
+export const dynamic = 'force-dynamic'
+
 export default async function HomePage({ searchParams }: Props) {
   const page = parseInt((searchParams?.pagina as string) || '1')
   const articles = await getPosts({ page, perPage: 10 })

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- remove static export config to permit dynamic rendering
- mark home page as dynamic and type post mappings for TS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive setup prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad98e470d88332869948260251dec2