### PR TITLE
Configure WordPress GraphQL endpoint

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,2 @@
-SITE_URL=http://localhost:3000
+SITE_URL=https://green-news.ro
 WP_GRAPHQL_ENDPOINT=https://cms.green-news.ro/wp/graphql

--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ Acest proiect este un site de știri static construit cu Next.js 14 (App Router)
    ```
 
 Fișierele statice vor fi generate în directorul `out/` și pot fi încărcate pe hostingul tău (de exemplu, CyberFolks).
+
+### Variabile de mediu
+
+Aplicația folosește un endpoint WordPress GraphQL pentru a prelua articole. Pentru dezvoltare locală creează un fișier `.env.local` cu următoarele valori:
+
+```
+SITE_URL=http://localhost:3000
+WP_GRAPHQL_ENDPOINT=https://cms.green-news.ro/wp/graphql
+```
+
+Un fișier `.env.production` este inclus pentru mediul de producție `green-news.ro`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,16 @@ const nextConfig = {
         hostname: 'images.unsplash.com',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'green-news.ro',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'cms.green-news.ro',
+        pathname: '/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- add local and production environment files with WordPress GraphQL endpoint
- allow loading remote images from WordPress hosts
- document required environment variables for CMS integration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae94824e748332ba7050f15ec3a13c