### PR TITLE
Improve GraphQL error handling

### DIFF
--- a/app/autor/[slug]/page.tsx
+++ b/app/autor/[slug]/page.tsx
@@ -13,20 +13,27 @@ interface Props {
 
 export default async function AuthorPage({ params, searchParams }: Props) {
   const page = parseInt((searchParams?.pagina as string) || '1')
-  const { author, posts } = await getAuthorBySlug(params.slug, { page, perPage: 10 })
-  if (!author) return <div>Autor necunoscut.</div>
+  try {
+    const { author, posts } = await getAuthorBySlug(params.slug, { page, perPage: 10 })
+    if (!author) return <div>Autor necunoscut.</div>
 
-  return (
-    <div>
-      <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: `Autor: ${author.name}` }]} />
-      <h1 className="text-3xl font-bold mb-6">Autor: {author.name}</h1>
-      <div className="space-y-8">
-        {posts.length === 0 ? (
-          <p className="text-gray-500">Nu există articole scrise de acest autor.</p>
-        ) : (
-          posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
-        )}
+    return (
+      <div>
+        <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: `Autor: ${author.name}` }]} />
+        <h1 className="text-3xl font-bold mb-6">Autor: {author.name}</h1>
+        <div className="space-y-8">
+          {posts.length === 0 ? (
+            <p className="text-gray-500">Nu există articole scrise de acest autor.</p>
+          ) : (
+            posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
+          )}
+        </div>
       </div>
-    </div>
-  )
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <p className="text-red-500">Eroare la încărcarea autorului.</p>
+    )
+  }
 }

--- a/app/categorie/[slug]/page.tsx
+++ b/app/categorie/[slug]/page.tsx
@@ -15,45 +15,56 @@ interface Props {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { category } = await getCategoryBySlug(params.slug, { page: 1, perPage: 1 })
-  if (!category) return { title: 'Categorie' }
-  const url = `${siteUrl}/categorie/${category.slug}`
-  return {
-    title: category.name,
-    description: `Știri din categoria ${category.name}`,
-    alternates: { canonical: url },
+  try {
+    const { category } = await getCategoryBySlug(params.slug, { page: 1, perPage: 1 })
+    if (!category) return { title: 'Categorie' }
+    const url = `${siteUrl}/categorie/${category.slug}`
+    return {
+      title: category.name,
+      description: `Știri din categoria ${category.name}`,
+      alternates: { canonical: url },
+    }
+  } catch {
+    return { title: 'Categorie' }
   }
 }
 
 export default async function CategoryPage({ params, searchParams }: Props) {
   const page = parseInt((searchParams?.pagina as string) || '1')
-  const { category, posts } = await getCategoryBySlug(params.slug, { page, perPage: 10 })
-  if (!category) return <div>Categorie necunoscută.</div>
+  try {
+    const { category, posts } = await getCategoryBySlug(params.slug, { page, perPage: 10 })
+    if (!category) return <div>Categorie necunoscută.</div>
 
-  return (
-    <div>
-      <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: category.name }]} />
-      <h1 className="text-3xl font-bold mb-6">{category.name}</h1>
-      <div className="space-y-8">
-        {posts.length === 0 ? (
-          <p className="text-gray-500">Nu există articole în această categorie.</p>
-        ) : (
-          posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
-        )}
+    return (
+      <div>
+        <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: category.name }]} />
+        <h1 className="text-3xl font-bold mb-6">{category.name}</h1>
+        <div className="space-y-8">
+          {posts.length === 0 ? (
+            <p className="text-gray-500">Nu există articole în această categorie.</p>
+          ) : (
+            posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
+          )}
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: [
+                { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
+                { '@type': 'ListItem', position: 2, name: category.name, item: `${siteUrl}/categorie/${category.slug}` },
+              ],
+            }),
+          }}
+        />
       </div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'BreadcrumbList',
-            itemListElement: [
-              { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
-              { '@type': 'ListItem', position: 2, name: category.name, item: `${siteUrl}/categorie/${category.slug}` },
-            ],
-          }),
-        }}
-      />
-    </div>
-  )
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <p className="text-red-500">Eroare la încărcarea categoriei.</p>
+    )
+  }
 }

--- a/app/cautare/page.tsx
+++ b/app/cautare/page.tsx
@@ -8,28 +8,35 @@ interface Props {
 export default async function SearchPage({ searchParams }: Props) {
   const term = (searchParams?.q as string) || ''
   const page = parseInt((searchParams?.pagina as string) || '1')
-  const results = term ? await searchPosts(term, { page, perPage: 10 }) : []
+  try {
+    const results = term ? await searchPosts(term, { page, perPage: 10 }) : []
 
-  return (
-    <div>
-      <h1 className="text-3xl font-bold mb-4">Căutare</h1>
-      <form className="mb-4">
-        <input
-          type="text"
-          name="q"
-          defaultValue={term}
-          placeholder="Caută..."
-          className="border p-2 w-full"
-        />
-      </form>
-      {term && results.length === 0 && (
-        <p className="text-gray-500">Nu am găsit articole.</p>
-      )}
-      <div className="space-y-8">
-        {results.map((a) => (
-          <ArticleCard key={a.slug} article={a} />
-        ))}
+    return (
+      <div>
+        <h1 className="text-3xl font-bold mb-4">Căutare</h1>
+        <form className="mb-4">
+          <input
+            type="text"
+            name="q"
+            defaultValue={term}
+            placeholder="Caută..."
+            className="border p-2 w-full"
+          />
+        </form>
+        {term && results.length === 0 && (
+          <p className="text-gray-500">Nu am găsit articole.</p>
+        )}
+        <div className="space-y-8">
+          {results.map((a) => (
+            <ArticleCard key={a.slug} article={a} />
+          ))}
+        </div>
       </div>
-    </div>
-  )
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <p className="text-red-500">Eroare la căutare.</p>
+    )
+  }
 }

--- a/app/eticheta/[slug]/page.tsx
+++ b/app/eticheta/[slug]/page.tsx
@@ -13,20 +13,27 @@ interface Props {
 
 export default async function TagPage({ params, searchParams }: Props) {
   const page = parseInt((searchParams?.pagina as string) || '1')
-  const { tag, posts } = await getTagBySlug(params.slug, { page, perPage: 10 })
-  if (!tag) return <div>Eticheta nu există.</div>
+  try {
+    const { tag, posts } = await getTagBySlug(params.slug, { page, perPage: 10 })
+    if (!tag) return <div>Eticheta nu există.</div>
 
-  return (
-    <div>
-      <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: `Etichetă: ${tag.name}` }]} />
-      <h1 className="text-3xl font-bold mb-6">Etichetă: {tag.name}</h1>
-      <div className="space-y-8">
-        {posts.length === 0 ? (
-          <p className="text-gray-500">Nu există articole pentru această etichetă.</p>
-        ) : (
-          posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
-        )}
+    return (
+      <div>
+        <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: `Etichetă: ${tag.name}` }]} />
+        <h1 className="text-3xl font-bold mb-6">Etichetă: {tag.name}</h1>
+        <div className="space-y-8">
+          {posts.length === 0 ? (
+            <p className="text-gray-500">Nu există articole pentru această etichetă.</p>
+          ) : (
+            posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
+          )}
+        </div>
       </div>
-    </div>
-  )
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <p className="text-red-500">Eroare la încărcarea etichetei.</p>
+    )
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,7 +35,14 @@ export const metadata: Metadata = {
 }
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
-  const categories = await getCategories()
+  let categories: { slug: string; name: string }[] = []
+  let catError = false
+  try {
+    categories = await getCategories()
+  } catch (e) {
+    console.error(e)
+    catError = true
+  }
   return (
     <html lang="ro" className={`${inter.variable} ${playfair.variable}`}>
       <head>
@@ -63,15 +70,19 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
               Green News România
             </Link>
             <nav className="hidden flex-1 justify-center gap-6 text-sm md:flex">
-              {categories.map((c) => (
-                <Link
-                  key={c.slug}
-                  href={`/categorie/${c.slug}`}
-                  className="hover:text-accent"
-                >
-                  {c.name}
-                </Link>
-              ))}
+              {catError ? (
+                <span className="text-red-500">Eroare la categoriile</span>
+              ) : (
+                categories.map((c) => (
+                  <Link
+                    key={c.slug}
+                    href={`/categorie/${c.slug}`}
+                    className="hover:text-accent"
+                  >
+                    {c.name}
+                  </Link>
+                ))
+              )}
             </nav>
             <Button variant="ghost" size="icon" asChild>
               <Link href="/cautare" aria-label="Căutare">
@@ -94,16 +105,20 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             <div>
               <h3 className="mb-2 font-serif font-semibold">Link-uri rapide</h3>
               <ul className="space-y-2">
-                {categories.map((c) => (
-                  <li key={c.slug}>
-                    <Link
-                      href={`/categorie/${c.slug}`}
-                      className="hover:text-accent"
-                    >
-                      {c.name}
-                    </Link>
-                  </li>
-                ))}
+                {catError ? (
+                  <li className="text-red-500">Eroare la categoriile</li>
+                ) : (
+                  categories.map((c) => (
+                    <li key={c.slug}>
+                      <Link
+                        href={`/categorie/${c.slug}`}
+                        className="hover:text-accent"
+                      >
+                        {c.name}
+                      </Link>
+                    </li>
+                  ))
+                )}
                 <li>
                   <Link href="/contact" className="hover:text-accent">
                     Contact

--- a/app/news-sitemap.xml/route.ts
+++ b/app/news-sitemap.xml/route.ts
@@ -4,20 +4,25 @@ import { siteUrl } from '@/lib/utils'
 export const dynamic = 'force-static'
 
 export async function GET() {
-  const posts = await getPosts({ page: 1, perPage: 100 })
-  const recent = posts.filter(
-    (p) => Date.now() - new Date(p.date).getTime() <= 48 * 60 * 60 * 1000
-  )
-  const items = recent
-    .map(
-      (p) =>
-        `<url><loc>${siteUrl}/stiri/${p.slug}</loc><news:news><news:publication><news:name>Green News România</news:name><news:language>ro</news:language></news:publication><news:publication_date>${p.date}</news:publication_date><news:title>${p.title}</news:title></news:news></url>`
+  try {
+    const posts = await getPosts({ page: 1, perPage: 100 })
+    const recent = posts.filter(
+      (p) => Date.now() - new Date(p.date).getTime() <= 48 * 60 * 60 * 1000
     )
-    .join('')
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">\n${items}\n</urlset>`
-  return new Response(xml, {
-    headers: {
-      'Content-Type': 'application/xml',
-    },
-  })
+    const items = recent
+      .map(
+        (p) =>
+          `<url><loc>${siteUrl}/stiri/${p.slug}</loc><news:news><news:publication><news:name>Green News România</news:name><news:language>ro</news:language></news:publication><news:publication_date>${p.date}</news:publication_date><news:title>${p.title}</news:title></news:news></url>`
+      )
+      .join('')
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">\n${items}\n</urlset>`
+    return new Response(xml, {
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    })
+  } catch (e) {
+    console.error(e)
+    return new Response('Error generating news sitemap', { status: 500 })
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,32 +12,39 @@ export const dynamic = 'force-dynamic'
 
 export default async function HomePage({ searchParams }: Props) {
   const page = parseInt((searchParams?.pagina as string) || '1')
-  const [featured, articles] = await Promise.all([
-    getFeaturedPost(),
-    getPosts({ page, perPage: 9 }),
-  ])
-  const list = featured
-    ? articles.filter((a) => a.slug !== featured.slug)
-    : articles
-  return (
-    <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
-      <div className="space-y-8">
-        {featured && <FeaturedArticle article={featured} />}
-        {list.length === 0 ? (
-          <p className="text-gray-500">Nu există articole.</p>
-        ) : (
-          <div className="grid gap-6 sm:grid-cols-2">
-            {list.map((a) => (
-              <ArticleCard key={a.slug} article={a} />
-            ))}
-          </div>
-        )}
+  try {
+    const [featured, articles] = await Promise.all([
+      getFeaturedPost(),
+      getPosts({ page, perPage: 9 }),
+    ])
+    const list = featured
+      ? articles.filter((a) => a.slug !== featured.slug)
+      : articles
+    return (
+      <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-8">
+          {featured && <FeaturedArticle article={featured} />}
+          {list.length === 0 ? (
+            <p className="text-gray-500">Nu există articole.</p>
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2">
+              {list.map((a) => (
+                <ArticleCard key={a.slug} article={a} />
+              ))}
+            </div>
+          )}
+        </div>
+        <aside className="space-y-8">
+          <AdsenseSlot />
+          <SidebarPopular />
+          <AdsenseSlot />
+        </aside>
       </div>
-      <aside className="space-y-8">
-        <AdsenseSlot />
-        <SidebarPopular />
-        <AdsenseSlot />
-      </aside>
-    </div>
-  )
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <p className="text-red-500">Eroare la încărcarea articolelor.</p>
+    )
+  }
 }

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -4,17 +4,22 @@ import { siteUrl } from '@/lib/utils'
 export const dynamic = 'force-static'
 
 export async function GET() {
-  const posts = await getPosts({ page: 1, perPage: 100 })
-  const urls = posts
-    .map(
-      (p) =>
-        `<url><loc>${siteUrl}/stiri/${p.slug}</loc><lastmod>${p.modified}</lastmod></url>`
-    )
-    .join('')
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<url><loc>${siteUrl}</loc></url>${urls}\n</urlset>`
-  return new Response(xml, {
-    headers: {
-      'Content-Type': 'application/xml',
-    },
-  })
+  try {
+    const posts = await getPosts({ page: 1, perPage: 100 })
+    const urls = posts
+      .map(
+        (p) =>
+          `<url><loc>${siteUrl}/stiri/${p.slug}</loc><lastmod>${p.modified}</lastmod></url>`
+      )
+      .join('')
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n<url><loc>${siteUrl}</loc></url>${urls}\n</urlset>`
+    return new Response(xml, {
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    })
+  } catch (e) {
+    console.error(e)
+    return new Response('Error generating sitemap', { status: 500 })
+  }
 }

--- a/app/stiri/[slug]/page.tsx
+++ b/app/stiri/[slug]/page.tsx
@@ -19,112 +19,123 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const article = await getPostBySlug(params.slug)
-  if (!article)
+  try {
+    const article = await getPostBySlug(params.slug)
+    if (!article)
+      return {
+        title: 'Articol',
+      }
+    const url = `${siteUrl}/stiri/${article.slug}`
     return {
-      title: 'Articol',
-    }
-  const url = `${siteUrl}/stiri/${article.slug}`
-  return {
-    title: article.title,
-    description: article.excerpt,
-    openGraph: {
       title: article.title,
       description: article.excerpt,
-      type: 'article',
-      images: article.image ? [{ url: article.image }] : undefined,
-      url,
-    },
-    alternates: { canonical: url },
+      openGraph: {
+        title: article.title,
+        description: article.excerpt,
+        type: 'article',
+        images: article.image ? [{ url: article.image }] : undefined,
+        url,
+      },
+      alternates: { canonical: url },
+    }
+  } catch {
+    return { title: 'Articol' }
   }
 }
 
 export default async function ArticlePage({ params }: Props) {
-  const article = await getPostBySlug(params.slug)
-  if (!article) return <div>Articolul nu a fost găsit.</div>
-  const recommended = (await getPosts({ page: 1, perPage: 3 })).filter(
-    (p) => p.slug !== article.slug
-  )
+  try {
+    const article = await getPostBySlug(params.slug)
+    if (!article) return <div>Articolul nu a fost găsit.</div>
+    const recommended = (await getPosts({ page: 1, perPage: 3 })).filter(
+      (p) => p.slug !== article.slug
+    )
 
-  return (
-    <div className="mx-auto max-w-7xl">
-      <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: article.title }]} />
-      <div className="lg:flex lg:gap-8">
-        <article className="flex-1">
-          <h1 className="mb-4 text-4xl font-serif font-bold leading-tight">
-            {article.title}
-          </h1>
-          {article.image && (
-            <Image
-              src={article.image}
-              alt={article.title}
-              width={1200}
-              height={600}
-              className="mb-6 w-full rounded-xl object-cover"
-            />
-          )}
-          <ProseContent html={article.content} />
-          <ShareBar title={article.title} />
-          <AdsenseSlot className="my-8 w-full min-h-[250px]" />
-          {recommended.length > 0 && (
-            <div className="mt-12 space-y-6">
-              <h2 className="text-2xl font-serif font-bold">
-                Articole recomandate
-              </h2>
-              <div className="grid gap-6 md:grid-cols-3">
-                {recommended.map((a) => (
-                  <ArticleCard key={a.slug} article={a} />
-                ))}
+    return (
+      <div className="mx-auto max-w-7xl">
+        <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: article.title }]} />
+        <div className="lg:flex lg:gap-8">
+          <article className="flex-1">
+            <h1 className="mb-4 text-4xl font-serif font-bold leading-tight">
+              {article.title}
+            </h1>
+            {article.image && (
+              <Image
+                src={article.image}
+                alt={article.title}
+                width={1200}
+                height={600}
+                className="mb-6 w-full rounded-xl object-cover"
+              />
+            )}
+            <ProseContent html={article.content} />
+            <ShareBar title={article.title} />
+            <AdsenseSlot className="my-8 w-full min-h-[250px]" />
+            {recommended.length > 0 && (
+              <div className="mt-12 space-y-6">
+                <h2 className="text-2xl font-serif font-bold">
+                  Articole recomandate
+                </h2>
+                <div className="grid gap-6 md:grid-cols-3">
+                  {recommended.map((a) => (
+                    <ArticleCard key={a.slug} article={a} />
+                  ))}
+                </div>
               </div>
-            </div>
-          )}
-        </article>
-        <aside className="mt-8 space-y-6 lg:mt-0 lg:w-80">
-          <AdsenseSlot className="w-full min-h-[600px]" />
-          <SidebarPopular />
-        </aside>
-      </div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'BreadcrumbList',
-            itemListElement: [
-              { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
-              {
-                '@type': 'ListItem',
-                position: 2,
-                name: article.title,
-                item: `${siteUrl}/stiri/${article.slug}`,
+            )}
+          </article>
+          <aside className="mt-8 space-y-6 lg:mt-0 lg:w-80">
+            <AdsenseSlot className="w-full min-h-[600px]" />
+            <SidebarPopular />
+          </aside>
+        </div>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: [
+                { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
+                {
+                  '@type': 'ListItem',
+                  position: 2,
+                  name: article.title,
+                  item: `${siteUrl}/stiri/${article.slug}`,
+                },
+              ],
+            }),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'NewsArticle',
+              headline: article.title,
+              image: [article.image],
+              datePublished: article.date,
+              dateModified: article.modified,
+              author: { '@type': 'Person', name: article.author.name },
+              publisher: {
+                '@type': 'Organization',
+                name: 'Green News România',
+                logo: { '@type': 'ImageObject', url: `${siteUrl}/logo.png` },
               },
-            ],
-          }),
-        }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'NewsArticle',
-            headline: article.title,
-            image: [article.image],
-            datePublished: article.date,
-            dateModified: article.modified,
-            author: { '@type': 'Person', name: article.author.name },
-            publisher: {
-              '@type': 'Organization',
-              name: 'Green News România',
-              logo: { '@type': 'ImageObject', url: `${siteUrl}/logo.png` },
-            },
-            mainEntityOfPage: {
-              '@type': 'WebPage',
-              '@id': `${siteUrl}/stiri/${article.slug}`,
-            },
-          }),
-        }}
-      />
-    </div>
-  )
+              mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': `${siteUrl}/stiri/${article.slug}`,
+              },
+            }),
+          }}
+        />
+      </div>
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <p className="text-red-500">Eroare la încărcarea articolului.</p>
+    )
+  }
 }

--- a/components/SidebarPopular.tsx
+++ b/components/SidebarPopular.tsx
@@ -2,23 +2,33 @@ import Link from 'next/link'
 import { getPosts } from '@/lib/wp'
 
 export default async function SidebarPopular() {
-  const popular = await getPosts({ page: 1, perPage: 3 })
-  return (
-    <aside className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
-      <h3 className="text-lg font-serif font-semibold">Cele mai citite</h3>
-      {popular.length === 0 ? (
-        <p className="text-sm text-gray-500">Nu există articole populare.</p>
-      ) : (
-        <ul className="space-y-2">
-          {popular.map((article) => (
-            <li key={article.slug}>
-              <Link href={`/stiri/${article.slug}`} className="hover:text-accent">
-                {article.title}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </aside>
-  )
+  try {
+    const popular = await getPosts({ page: 1, perPage: 3 })
+    return (
+      <aside className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
+        <h3 className="text-lg font-serif font-semibold">Cele mai citite</h3>
+        {popular.length === 0 ? (
+          <p className="text-sm text-gray-500">Nu există articole populare.</p>
+        ) : (
+          <ul className="space-y-2">
+            {popular.map((article) => (
+              <li key={article.slug}>
+                <Link href={`/stiri/${article.slug}`} className="hover:text-accent">
+                  {article.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </aside>
+    )
+  } catch (e) {
+    console.error(e)
+    return (
+      <aside className="space-y-4 rounded-lg bg-white p-4 shadow-sm">
+        <h3 className="text-lg font-serif font-semibold">Cele mai citite</h3>
+        <p className="text-sm text-red-500">Eroare la încărcarea articolelor.</p>
+      </aside>
+    )
+  }
 }

--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -26,9 +26,15 @@ async function fetchGraphQL<T>(query: string, variables: any): Promise<T> {
     body: JSON.stringify({ query, variables }),
     next: { revalidate: 60 },
   })
-  if (!res.ok) throw new Error('Fetch error')
+  if (!res.ok) {
+    console.error('GraphQL fetch error', res.status)
+    throw new Error(`Fetch error: ${res.status}`)
+  }
   const json = await res.json()
-  if (json.errors) throw new Error('GraphQL error')
+  if (json.errors) {
+    console.error('GraphQL error', res.status, json.errors)
+    throw new Error(`GraphQL error: ${JSON.stringify(json.errors)}`)
+  }
   return json.data
 }
 
@@ -52,99 +58,67 @@ function mapPost(node: any): Post {
 
 export async function getCategories(): Promise<Term[]> {
   const query = `query Categories{\n    categories(first: 100){nodes{slug name}}\n  }`
-  try {
-    const data = await fetchGraphQL<any>(query, {})
-    return data.categories.nodes.map(
-      (c: any) => ({ slug: c.slug, name: c.name })
-    ) as Term[]
-  } catch {
-    return []
-  }
+  const data = await fetchGraphQL<any>(query, {})
+  return data.categories.nodes.map(
+    (c: any) => ({ slug: c.slug, name: c.name })
+  ) as Term[]
 }
 
 export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   const query = `query Posts($offset: Int!, $size: Int!){\n    posts(where:{offsetPagination:{offset:$offset, size:$size}}){\n      nodes{\n        slug title excerpt content date modified\n        categories{nodes{slug name}}\n        tags{nodes{slug name}}\n        author{node{slug name}}\n        featuredImage{node{sourceUrl}}\n      }\n    }\n  }`
   const variables = { offset: (page - 1) * perPage, size: perPage }
-  try {
-    const data = await fetchGraphQL<any>(query, variables)
-    return data.posts.nodes.map(mapPost) as Post[]
-  } catch {
-    return []
-  }
+  const data = await fetchGraphQL<any>(query, variables)
+  return data.posts.nodes.map(mapPost) as Post[]
 }
 
 export async function getFeaturedPost(): Promise<Post | undefined> {
   const query = `query Featured{\n    posts(where:{sticky:true}, first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
-  try {
-    const data = await fetchGraphQL<any>(query, {})
-    const node = data.posts.nodes[0]
-    return node ? mapPost(node) : undefined
-  } catch {
-    return undefined
-  }
+  const data = await fetchGraphQL<any>(query, {})
+  const node = data.posts.nodes[0]
+  return node ? mapPost(node) : undefined
 }
 
 export async function getPostBySlug(slug: string): Promise<Post | undefined> {
   const query = `query PostBySlug($slug: ID!){\n    post(id:$slug, idType:SLUG){\n      slug title excerpt content date modified\n      categories{nodes{slug name}}\n      tags{nodes{slug name}}\n      author{node{slug name}}\n      featuredImage{node{sourceUrl}}\n    }\n  }`
-  try {
-    const data = await fetchGraphQL<any>(query, { slug })
-    return data.post ? mapPost(data.post) : undefined
-  } catch {
-    return undefined
-  }
+  const data = await fetchGraphQL<any>(query, { slug })
+  return data.post ? mapPost(data.post) : undefined
 }
 
 export async function getCategoryBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   const query = `query Category($slug: ID!, $offset: Int!, $size: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
   const variables = { slug, offset: (page - 1) * perPage, size: perPage }
-  try {
-    const data = await fetchGraphQL<any>(query, variables)
-    return {
-      category: data.category ? { slug: data.category.slug, name: data.category.name } : undefined,
-      posts: data.category ? data.category.posts.nodes.map(mapPost) : [],
-    }
-  } catch {
-    return { category: undefined, posts: [] }
+  const data = await fetchGraphQL<any>(query, variables)
+  return {
+    category: data.category ? { slug: data.category.slug, name: data.category.name } : undefined,
+    posts: data.category ? data.category.posts.nodes.map(mapPost) : [],
   }
 }
 
 export async function getTagBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   const query = `query Tag($slug: ID!, $offset: Int!, $size: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
   const variables = { slug, offset: (page - 1) * perPage, size: perPage }
-  try {
-    const data = await fetchGraphQL<any>(query, variables)
-    return {
-      tag: data.tag ? { slug: data.tag.slug, name: data.tag.name } : undefined,
-      posts: data.tag ? data.tag.posts.nodes.map(mapPost) : [],
-    }
-  } catch {
-    return { tag: undefined, posts: [] }
+  const data = await fetchGraphQL<any>(query, variables)
+  return {
+    tag: data.tag ? { slug: data.tag.slug, name: data.tag.name } : undefined,
+    posts: data.tag ? data.tag.posts.nodes.map(mapPost) : [],
   }
 }
 
 export async function getAuthorBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   const query = `query Author($slug: ID!, $offset: Int!, $size: Int!){\n    user(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} featuredImage{node{sourceUrl}} author{node{slug name}}}}\n    }\n  }`
   const variables = { slug, offset: (page - 1) * perPage, size: perPage }
-  try {
-    const data = await fetchGraphQL<any>(query, variables)
-    return {
-      author: data.user ? { slug: data.user.slug, name: data.user.name } : undefined,
-      posts: data.user ? data.user.posts.nodes.map(mapPost) : [],
-    }
-  } catch {
-    return { author: undefined, posts: [] }
+  const data = await fetchGraphQL<any>(query, variables)
+  return {
+    author: data.user ? { slug: data.user.slug, name: data.user.name } : undefined,
+    posts: data.user ? data.user.posts.nodes.map(mapPost) : [],
   }
 }
 
 export async function searchPosts(term: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   const query = `query Search($term: String!, $offset: Int!, $size: Int!){\n    posts(where:{search:$term, offsetPagination:{offset:$offset, size:$size}}){\n      nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}\n    }\n  }`
   const variables = { term, offset: (page - 1) * perPage, size: perPage }
-  try {
-    const data = await fetchGraphQL<any>(query, variables)
-    return data.posts.nodes.map(mapPost) as Post[]
-  } catch {
-    return []
-  }
+  const data = await fetchGraphQL<any>(query, variables)
+  return data.posts.nodes.map(mapPost) as Post[]
 }
 
 export const fixtures = {


### PR DESCRIPTION
## Summary
- log GraphQL response status and errors while throwing descriptive exceptions
- let WordPress helpers propagate errors and surface them in pages/components with user-friendly messages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9f894cb483328dbee593833b979e