### PR TITLE
Refactor WPGraphQL pagination to use first and slice

### DIFF
--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -32,7 +32,7 @@ async function fetchGraphQL<T>(query: string, variables: any): Promise<T> {
   }
   const json = await res.json()
   if (json.errors) {
-    console.error('GraphQL error', res.status, json.errors)
+    console.error('GraphQL error', JSON.stringify(json.errors, null, 2))
     throw new Error(`GraphQL error: ${JSON.stringify(json.errors)}`)
   }
   return json.data
@@ -44,14 +44,14 @@ function mapPost(node: any): Post {
     title: node.title,
     excerpt: node.excerpt,
     content: node.content,
-    image: node.featuredImage?.node?.sourceUrl || '',
-    date: node.date || '',
-    modified: node.modified || '',
-    categories: node.categories?.nodes?.map((c: any) => ({ slug: c.slug, name: c.name })) || [],
-    tags: node.tags?.nodes?.map((t: any) => ({ slug: t.slug, name: t.name })) || [],
+    image: node.featuredImage?.node?.sourceUrl ?? '',
+    date: node.date ?? '',
+    modified: node.modified ?? '',
+    categories: node.categories?.nodes?.map((c: any) => ({ slug: c.slug, name: c.name })) ?? [],
+    tags: node.tags?.nodes?.map((t: any) => ({ slug: t.slug, name: t.name })) ?? [],
     author: {
-      slug: node.author?.node?.slug || '',
-      name: node.author?.node?.name || '',
+      slug: node.author?.node?.slug ?? '',
+      name: node.author?.node?.name ?? '',
     },
   }
 }
@@ -65,60 +65,70 @@ export async function getCategories(): Promise<Term[]> {
 }
 
 export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Posts($offset: Int!, $size: Int!){\n    posts(where:{offsetPagination:{offset:$offset, size:$size}}){\n      nodes{\n        slug title excerpt content date modified\n        categories{nodes{slug name}}\n        tags{nodes{slug name}}\n        author{node{slug name}}\n        featuredImage{node{sourceUrl}}\n      }\n    }\n  }`
-  const variables = { offset: (page - 1) * perPage, size: perPage }
+  const query = `query Posts($first: Int!){\n    posts(first:$first){\n      nodes{\n        slug title excerpt content date modified\n        categories{nodes{slug name}}\n        tags{nodes{slug name}}\n        author{node{slug name}}\n        featuredImage{node{sourceUrl}}\n      }\n    }\n  }`
+  const variables = { first: perPage * page }
   const data = await fetchGraphQL<any>(query, variables)
-  return data.posts.nodes.map(mapPost) as Post[]
+  const start = (page - 1) * perPage
+  const end = start + perPage
+  return data.posts.nodes.slice(start, end).map(mapPost) as Post[]
 }
 
 export async function getFeaturedPost(): Promise<Post | undefined> {
   const query = `query Featured{\n    posts(where:{sticky:true}, first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
   const data = await fetchGraphQL<any>(query, {})
-  const node = data.posts.nodes[0]
+  const node = data?.posts?.nodes?.[0]
   return node ? mapPost(node) : undefined
 }
 
 export async function getPostBySlug(slug: string): Promise<Post | undefined> {
   const query = `query PostBySlug($slug: ID!){\n    post(id:$slug, idType:SLUG){\n      slug title excerpt content date modified\n      categories{nodes{slug name}}\n      tags{nodes{slug name}}\n      author{node{slug name}}\n      featuredImage{node{sourceUrl}}\n    }\n  }`
   const data = await fetchGraphQL<any>(query, { slug })
-  return data.post ? mapPost(data.post) : undefined
+  return data?.post ? mapPost(data.post) : undefined
 }
 
 export async function getCategoryBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Category($slug: ID!, $offset: Int!, $size: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
-  const variables = { slug, offset: (page - 1) * perPage, size: perPage }
+  const query = `query Category($slug: ID!, $first: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name\n      posts(first:$first){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
+  const variables = { slug, first: perPage * page }
   const data = await fetchGraphQL<any>(query, variables)
+  const start = (page - 1) * perPage
+  const end = start + perPage
   return {
     category: data.category ? { slug: data.category.slug, name: data.category.name } : undefined,
-    posts: data.category ? data.category.posts.nodes.map(mapPost) : [],
+    posts: data.category ? data.category.posts.nodes.slice(start, end).map(mapPost) : [],
   }
 }
 
 export async function getTagBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Tag($slug: ID!, $offset: Int!, $size: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
-  const variables = { slug, offset: (page - 1) * perPage, size: perPage }
+  const query = `query Tag($slug: ID!, $first: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name\n      posts(first:$first){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n    }\n  }`
+  const variables = { slug, first: perPage * page }
   const data = await fetchGraphQL<any>(query, variables)
+  const start = (page - 1) * perPage
+  const end = start + perPage
   return {
     tag: data.tag ? { slug: data.tag.slug, name: data.tag.name } : undefined,
-    posts: data.tag ? data.tag.posts.nodes.map(mapPost) : [],
+    posts: data.tag ? data.tag.posts.nodes.slice(start, end).map(mapPost) : [],
   }
 }
 
 export async function getAuthorBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Author($slug: ID!, $offset: Int!, $size: Int!){\n    user(id:$slug, idType:SLUG){\n      slug name\n      posts(where:{offsetPagination:{offset:$offset, size:$size}}){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} featuredImage{node{sourceUrl}} author{node{slug name}}}}\n    }\n  }`
-  const variables = { slug, offset: (page - 1) * perPage, size: perPage }
+  const query = `query Author($slug: ID!, $first: Int!){\n    user(id:$slug, idType:SLUG){\n      slug name\n      posts(first:$first){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} featuredImage{node{sourceUrl}} author{node{slug name}}}}\n    }\n  }`
+  const variables = { slug, first: perPage * page }
   const data = await fetchGraphQL<any>(query, variables)
+  const start = (page - 1) * perPage
+  const end = start + perPage
   return {
     author: data.user ? { slug: data.user.slug, name: data.user.name } : undefined,
-    posts: data.user ? data.user.posts.nodes.map(mapPost) : [],
+    posts: data.user ? data.user.posts.nodes.slice(start, end).map(mapPost) : [],
   }
 }
 
 export async function searchPosts(term: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
-  const query = `query Search($term: String!, $offset: Int!, $size: Int!){\n    posts(where:{search:$term, offsetPagination:{offset:$offset, size:$size}}){\n      nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}\n    }\n  }`
-  const variables = { term, offset: (page - 1) * perPage, size: perPage }
+  const query = `query Search($term: String!, $first: Int!){\n    posts(where:{search:$term}, first:$first){\n      nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}\n    }\n  }`
+  const variables = { term, first: perPage * page }
   const data = await fetchGraphQL<any>(query, variables)
-  return data.posts.nodes.map(mapPost) as Post[]
+  const start = (page - 1) * perPage
+  const end = start + perPage
+  return data.posts.nodes.slice(start, end).map(mapPost) as Post[]
 }
 
 export const fixtures = {


### PR DESCRIPTION
## Summary
- replace `offsetPagination` with `first` in all WPGraphQL queries
- paginate in JavaScript using `slice()`
- guard `mapPost` against missing featured image or author info and improve GraphQL error logging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aea45cf4a88332a42cff4a3e6f743e