### PR TITLE
Fix featured post query and handle failures on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default async function HomePage({ searchParams }: Props) {
   const page = parseInt((searchParams?.pagina as string) || '1')
   try {
     const [featured, articles] = await Promise.all([
-      getFeaturedPost(),
+      getFeaturedPost().catch(() => undefined),
       getPosts({ page, perPage: 9 }),
     ])
     const list = featured

--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -74,7 +74,7 @@ export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perP
 }
 
 export async function getFeaturedPost(): Promise<Post | undefined> {
-  const query = `query Featured{\n    posts(where:{sticky:true}, first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
+  const query = `query Featured{\n    posts(where:{onlySticky:true}, first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
   const data = await fetchGraphQL<any>(query, {})
   const node = data?.posts?.nodes?.[0]
   return node ? mapPost(node) : undefined


### PR DESCRIPTION
## Summary
- fix featured article query to use `onlySticky` filter
- avoid homepage crash by tolerating featured post fetch failures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68aea68dc7c08332a66b20220374d042