### PR TITLE
Enable static export

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Acest proiect este un site de știri static construit cu Next.js 14 (App Router)
    pnpm i
    ```
 
-2. Build al aplicației:
+2. Build și export static al aplicației:
 
    ```bash
    pnpm build
    ```
 
-3. Export static:
+   Fișierele statice vor fi generate în directorul `out/` și pot fi încărcate pe hostingul tău (de exemplu, CyberFolks).
+
+   Pentru o previzualizare locală după build poți rula:
 
    ```bash
-   pnpm export
+   pnpm start
    ```
-
-Fișierele statice vor fi generate în directorul `out/` și pot fi încărcate pe hostingul tău (de exemplu, CyberFolks).
 
 ### Variabile de mediu
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   images: {
+    // `output: "export"` disables the default Image Optimization, so all images
+    // are served as static files. `unoptimized: true` is set automatically but
+    // included here for clarity.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "export": "next export"
+    "start": "npx serve out",
+    "lint": "next lint"
   },
   "dependencies": {
     "next": "^14.0.0",


### PR DESCRIPTION
## Summary
- add `output: 'export'` configuration to generate static build
- expose new `start` script using `npx serve out`
- document updated build/export process

## Testing
- `npm run build` *(fails: Failed to fetch `Inter` and `Playfair Display` fonts from Google Fonts)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aea938d9f083328109bb13bae6d3d9