### PR TITLE
Handle missing post content and remove unsupported sticky filter

### DIFF
--- a/components/ProseContent.tsx
+++ b/components/ProseContent.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import AdsenseSlot from './AdsenseSlot'
 
-export default function ProseContent({ html }: { html: string }) {
+export default function ProseContent({ html }: { html?: string | null }) {
+  if (!html) return null
   const parts = html.split(/<\/p>/i)
   const content: React.ReactNode[] = []
 

--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -89,7 +89,7 @@ export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perP
 
 export async function getFeaturedPost(): Promise<Post | undefined> {
   try {
-    const query = `query Featured{\n    posts(where:{onlySticky:true}, first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
+    const query = `query Featured{\n    posts(first:1){nodes{slug title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl}}}}\n  }`
     const data = await fetchGraphQL<any>(query, {})
     const node = data?.posts?.nodes?.[0]
     return node ? mapPost(node) : undefined


### PR DESCRIPTION
## Summary
- avoid runtime errors when post content is missing
- drop unsupported `onlySticky` filter from featured post query

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build` *(fails: Error: connect ENETUNREACH 185.171.185.225:443)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb2f82940833296871dafbb063a54