### PR TITLE
Add Google AdSense verification meta tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,6 +40,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   return (
     <html lang="ro">
       <head>
+        <meta name="google-adsense-account" content="ca-pub-9593023557482879" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
- add Google AdSense account meta tag in root layout for verification

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68aeb89da52483328d386ac13d1d0695