### PR TITLE
feat: integrate seo support

### DIFF
--- a/app/categorie/[slug]/page.tsx
+++ b/app/categorie/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
 import { getCategoryBySlug, getCategories, type Post } from '@/lib/wp'
-import type { Metadata } from 'next'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
 export async function generateStaticParams() {
@@ -13,29 +14,24 @@ interface Props {
   params: { slug: string }
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  try {
-    const { category } = await getCategoryBySlug(params.slug, { page: 1, perPage: 1 })
-    if (!category) return { title: 'Categorie' }
-    const url = `${siteUrl}/categorie/${category.slug}`
-    return {
-      title: category.name,
-      description: `Știri din categoria ${category.name}`,
-      alternates: { canonical: url },
-    }
-  } catch {
-    return { title: 'Categorie' }
-  }
-}
-
 export default async function CategoryPage({ params }: Props) {
   const page = 1
   try {
     const { category, posts } = await getCategoryBySlug(params.slug, { page, perPage: 10 })
     if (!category) return <div>Categorie necunoscută.</div>
+    const seoData = normalizeSeo({
+      seo: category.seo,
+      wpTitle: category.name,
+      wpExcerpt: `Știri din categoria ${category.name}`,
+      url: category.uri || `/categorie/${category.slug}`,
+      siteName: 'Green News România',
+      siteUrl,
+    })
 
     return (
-      <div>
+      <>
+        <SeoHead data={seoData} />
+        <div>
         <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: category.name }]} />
         <h1 className="text-3xl font-bold mb-6">{category.name}</h1>
         <div className="space-y-8">
@@ -45,20 +41,8 @@ export default async function CategoryPage({ params }: Props) {
             posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
           )}
         </div>
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'BreadcrumbList',
-              itemListElement: [
-                { '@type': 'ListItem', position: 1, name: 'Acasă', item: siteUrl },
-                { '@type': 'ListItem', position: 2, name: category.name, item: `${siteUrl}/categorie/${category.slug}` },
-              ],
-            }),
-          }}
-        />
-      </div>
+        </div>
+      </>
     )
   } catch (e) {
     console.error(e)

--- a/app/confidentialitate/page.tsx
+++ b/app/confidentialitate/page.tsx
@@ -1,10 +1,26 @@
 import ProseContent from '@/components/ProseContent'
+import { getPageBySlug } from '@/lib/wp'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
+import { siteUrl } from '@/lib/utils'
 
-export default function PrivacyPage() {
+export default async function PrivacyPage() {
+  const page = await getPageBySlug('confidentialitate').catch(() => undefined)
+  const seoData = normalizeSeo({
+    seo: page?.seo,
+    wpTitle: page?.title || 'Politica de confidențialitate',
+    wpExcerpt: page?.excerpt || 'Politica de confidențialitate',
+    url: page?.uri || '/confidentialitate',
+    siteName: 'Green News România',
+    siteUrl,
+  })
   return (
-    <div className="max-w-3xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Politica de confidențialitate</h1>
-      <ProseContent html="<p>Aceasta este politica noastră de confidențialitate.</p>" />
-    </div>
+    <>
+      <SeoHead data={seoData} />
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">{page?.title || 'Politica de confidențialitate'}</h1>
+        <ProseContent html={page?.content || '<p>Aceasta este politica noastră de confidențialitate.</p>'} />
+      </div>
+    </>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,10 +1,26 @@
 import ProseContent from '@/components/ProseContent'
+import { getPageBySlug } from '@/lib/wp'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
+import { siteUrl } from '@/lib/utils'
 
-export default function ContactPage() {
+export default async function ContactPage() {
+  const page = await getPageBySlug('contact').catch(() => undefined)
+  const seoData = normalizeSeo({
+    seo: page?.seo,
+    wpTitle: page?.title || 'Contact',
+    wpExcerpt: page?.excerpt || 'Contact',
+    url: page?.uri || '/contact',
+    siteName: 'Green News România',
+    siteUrl,
+  })
   return (
-    <div className="max-w-3xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Contact</h1>
-      <ProseContent html="<p>Ne poți scrie la <a href='mailto:contact@example.com'>contact@example.com</a>.</p>" />
-    </div>
+    <>
+      <SeoHead data={seoData} />
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">{page?.title || 'Contact'}</h1>
+        <ProseContent html={page?.content || "<p>Ne poți scrie la <a href='mailto:contact@example.com'>contact@example.com</a>.</p>"} />
+      </div>
+    </>
   )
 }

--- a/app/despre/page.tsx
+++ b/app/despre/page.tsx
@@ -1,10 +1,26 @@
 import ProseContent from '@/components/ProseContent'
+import { getPageBySlug } from '@/lib/wp'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
+import { siteUrl } from '@/lib/utils'
 
-export default function AboutPage() {
+export default async function AboutPage() {
+  const page = await getPageBySlug('despre').catch(() => undefined)
+  const seoData = normalizeSeo({
+    seo: page?.seo,
+    wpTitle: page?.title || 'Despre noi',
+    wpExcerpt: page?.excerpt || 'Despre noi',
+    url: page?.uri || '/despre',
+    siteName: 'Green News România',
+    siteUrl,
+  })
   return (
-    <div className="max-w-3xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Despre noi</h1>
-      <ProseContent html="<p>Suntem un site de știri fictiv.</p>" />
-    </div>
+    <>
+      <SeoHead data={seoData} />
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">{page?.title || 'Despre noi'}</h1>
+        <ProseContent html={page?.content || '<p>Suntem un site de știri fictiv.</p>'} />
+      </div>
+    </>
   )
 }

--- a/app/eticheta/[slug]/page.tsx
+++ b/app/eticheta/[slug]/page.tsx
@@ -1,6 +1,9 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
 import { getTagBySlug, fixtures, type Post } from '@/lib/wp'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
+import { siteUrl } from '@/lib/utils'
 
 export function generateStaticParams() {
   return fixtures.tags.map((t) => ({ slug: t.slug }))
@@ -15,9 +18,19 @@ export default async function TagPage({ params }: Props) {
   try {
     const { tag, posts } = await getTagBySlug(params.slug, { page, perPage: 10 })
     if (!tag) return <div>Eticheta nu există.</div>
+    const seoData = normalizeSeo({
+      seo: tag.seo,
+      wpTitle: tag.name,
+      wpExcerpt: `Articole etichetate ${tag.name}`,
+      url: tag.uri || `/eticheta/${tag.slug}`,
+      siteName: 'Green News România',
+      siteUrl,
+    })
 
     return (
-      <div>
+      <>
+        <SeoHead data={seoData} />
+        <div>
         <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: `Etichetă: ${tag.name}` }]} />
         <h1 className="text-3xl font-bold mb-6">Etichetă: {tag.name}</h1>
         <div className="space-y-8">
@@ -27,7 +40,8 @@ export default async function TagPage({ params }: Props) {
             posts.map((a: Post) => <ArticleCard key={a.slug} article={a} />)
           )}
         </div>
-      </div>
+        </div>
+      </>
     )
   } catch (e) {
     console.error(e)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,20 +2,34 @@ import ArticleCard from '@/components/ArticleCard'
 import SidebarPopular from '@/components/SidebarPopular'
 import AdsenseSlot from '@/components/AdsenseSlot'
 import FeaturedArticle from '@/components/FeaturedArticle'
-import { getPosts, getFeaturedPost } from '@/lib/wp'
+import { getPosts, getFeaturedPost, getPageBySlug } from '@/lib/wp'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
+import { siteUrl } from '@/lib/utils'
 
 export default async function HomePage() {
   const page = 1
   try {
-    const [featured, articles] = await Promise.all([
+    const [featured, articles, homepage] = await Promise.all([
       getFeaturedPost().catch(() => undefined),
       getPosts({ page, perPage: 9 }),
+      getPageBySlug('acasa').catch(() => undefined),
     ])
     const list = featured
       ? articles.filter((a) => a.slug !== featured.slug)
       : articles
+    const seoData = normalizeSeo({
+      seo: homepage?.seo,
+      wpTitle: homepage?.title,
+      wpExcerpt: homepage?.excerpt,
+      url: '/',
+      siteName: 'Green News România',
+      siteUrl,
+    })
     return (
-      <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
+      <>
+        <SeoHead data={seoData} />
+        <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
         <div className="space-y-8">
           {featured && <FeaturedArticle article={featured} />}
           {list.length === 0 ? (
@@ -33,7 +47,8 @@ export default async function HomePage() {
           <SidebarPopular />
           <AdsenseSlot />
         </aside>
-      </div>
+        </div>
+      </>
     )
   } catch (e) {
     console.error(e)

--- a/app/publicitate/page.tsx
+++ b/app/publicitate/page.tsx
@@ -1,10 +1,26 @@
 import ProseContent from '@/components/ProseContent'
+import { getPageBySlug } from '@/lib/wp'
+import SeoHead from '@/components/SeoHead'
+import { normalizeSeo } from '@/lib/seo'
+import { siteUrl } from '@/lib/utils'
 
-export default function AdsPage() {
+export default async function AdsPage() {
+  const page = await getPageBySlug('publicitate').catch(() => undefined)
+  const seoData = normalizeSeo({
+    seo: page?.seo,
+    wpTitle: page?.title || 'Publicitate',
+    wpExcerpt: page?.excerpt || 'Publicitate',
+    url: page?.uri || '/publicitate',
+    siteName: 'Green News România',
+    siteUrl,
+  })
   return (
-    <div className="max-w-3xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Publicitate</h1>
-      <ProseContent html="<p>Pentru spații publicitare, contactați-ne.</p>" />
-    </div>
+    <>
+      <SeoHead data={seoData} />
+      <div className="max-w-3xl mx-auto">
+        <h1 className="text-3xl font-bold mb-4">{page?.title || 'Publicitate'}</h1>
+        <ProseContent html={page?.content || '<p>Pentru spații publicitare, contactați-ne.</p>'} />
+      </div>
+    </>
   )
 }

--- a/components/SeoHead.tsx
+++ b/components/SeoHead.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head';
+
+export default function SeoHead({ data }: { data: ReturnType<typeof import('../lib/seo').normalizeSeo> }) {
+  return (
+    <Head>
+      {data.title && <title>{data.title}</title>}
+      {data.description && <meta name="description" content={data.description} />}
+      {data.canonical && <link rel="canonical" href={data.canonical} />}
+      {data.robots && <meta name="robots" content={data.robots} />}
+
+      {data.og?.title && <meta property="og:title" content={data.og.title} />}
+      {data.og?.description && <meta property="og:description" content={data.og.description} />}
+      {data.og?.type && <meta property="og:type" content={data.og.type} />}
+      {data.og?.url && <meta property="og:url" content={data.og.url} />}
+      {data.og?.siteName && <meta property="og:site_name" content={data.og.siteName} />}
+      {data.og?.image && <meta property="og:image" content={data.og.image} />}
+
+      <meta name="twitter:card" content={data.twitter?.card ?? 'summary_large_image'} />
+      {data.twitter?.title && <meta name="twitter:title" content={data.twitter.title} />}
+      {data.twitter?.description && <meta name="twitter:description" content={data.twitter.description} />}
+      {data.twitter?.image && <meta name="twitter:image" content={data.twitter.image} />}
+
+      {data.schema && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: data.schema }} />}
+    </Head>
+  );
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,60 @@
+export type WPSeo = {
+  title?: string | null;
+  metaDesc?: string | null;
+  canonical?: string | null;
+  robots?: string | null;
+  opengraphType?: string | null;
+  opengraphTitle?: string | null;
+  opengraphDescription?: string | null;
+  opengraphImage?: { sourceUrl?: string | null } | null;
+  twitterTitle?: string | null;
+  twitterDescription?: string | null;
+  twitterImage?: { sourceUrl?: string | null } | null;
+  breadcrumbs?: { text: string; url: string }[] | null;
+  schema?: { raw?: string | null } | null;
+};
+
+export function normalizeSeo(input: {
+  seo?: WPSeo | null;
+  wpTitle?: string;
+  wpExcerpt?: string;
+  url?: string;
+  siteName?: string;
+  siteUrl?: string;
+}) {
+  const { seo, wpTitle, wpExcerpt, url, siteName, siteUrl } = input;
+  const title = seo?.title ?? wpTitle ?? siteName ?? '';
+  const description = (seo?.metaDesc ?? wpExcerpt ?? '')
+    .replace(/<[^>]*>?/gm, '')
+    .slice(0, 160);
+  const canonical =
+    seo?.canonical ??
+    (url?.startsWith('http') ? url : `${siteUrl ?? ''}${url ?? ''}`);
+  const rawOg = seo?.opengraphImage?.sourceUrl ?? undefined;
+  const ogImage =
+    rawOg && !rawOg.startsWith('http') ? `${siteUrl ?? ''}${rawOg}` : rawOg;
+  const rawTw = seo?.twitterImage?.sourceUrl ?? rawOg;
+  const twImage =
+    rawTw && !rawTw.startsWith('http') ? `${siteUrl ?? ''}${rawTw}` : rawTw;
+  return {
+    title,
+    description,
+    canonical,
+    robots: seo?.robots ?? undefined,
+    og: {
+      title: seo?.opengraphTitle ?? title,
+      description: seo?.opengraphDescription ?? description,
+      type: seo?.opengraphType ?? 'article',
+      image: ogImage,
+      url: canonical,
+      siteName: siteName,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: seo?.twitterTitle ?? title,
+      description: seo?.twitterDescription ?? description,
+      image: twImage,
+    },
+    schema: seo?.schema?.raw ?? null,
+  };
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,4 +5,9 @@ export function cn(...inputs: any[]) {
   return twMerge(clsx(inputs))
 }
 
-export const siteUrl = process.env.SITE_URL || 'https://green-news.ro'
+export const siteUrl =
+  process.env.SITE_URL ||
+  (process.env.NODE_ENV === 'production'
+    ? 'https://green-news.ro'
+    : 'http://localhost:3000')
+


### PR DESCRIPTION
## Summary
- add normalizeSeo utility and SeoHead component for managing SEO tags
- fetch Yoast SEO data via GraphQL for posts, pages, categories and tags
- render dynamic metadata on home, article, taxonomy and static pages
- restore local env defaults and WP GraphQL endpoint for dev/production parity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: awaiting ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68aec7f8a6988332a7bc78c16a4dbc20