### PR TITLE
Remove unsupported WordPress GraphQL fields

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default async function HomePage() {
     const seoData = normalizeSeo({
       seo: homepage?.seo,
       wpTitle: homepage?.title,
-      wpExcerpt: homepage?.excerpt,
+      wpExcerpt: homepage?.excerpt ?? '',
       url: '/',
       siteName: 'Green News România',
       siteUrl,

--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -25,8 +25,8 @@ export interface Page {
   slug: string
   uri: string
   title: string
-  excerpt: string
   content: string
+  excerpt?: string
   seo?: WPSeo | null
 }
 
@@ -104,7 +104,7 @@ export async function getPosts({ page = 1, perPage = 10 }: { page?: number; perP
 
 export async function getFeaturedPost(): Promise<Post | undefined> {
   try {
-    const query = `query Featured{\n    posts(first:1){nodes{slug uri title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl altText mediaDetails{width height}}} seo{title metaDesc canonical robots opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl altText mediaDetails{width height}} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}}}\n  }`
+    const query = `query Featured{\n    posts(first:1){nodes{slug uri title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl altText mediaDetails{width height}}} seo{title metaDesc canonical opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl altText mediaDetails{width height}} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}}}\n  }`
     const data = await fetchGraphQL<any>(query, {})
     const node = data?.posts?.nodes?.[0]
     return node ? mapPost(node) : undefined
@@ -116,7 +116,7 @@ export async function getFeaturedPost(): Promise<Post | undefined> {
 
 export async function getPostBySlug(slug: string): Promise<Post | undefined> {
   try {
-    const query = `query PostBySlug($slug: ID!){\n    post(id:$slug, idType:SLUG){\n      slug uri title excerpt content date modified\n      categories{nodes{slug name}}\n      tags{nodes{slug name}}\n      author{node{slug name}}\n      featuredImage{node{sourceUrl altText mediaDetails{width height}}}\n      seo{title metaDesc canonical robots opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl altText mediaDetails{width height}} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n    }\n  }`
+    const query = `query PostBySlug($slug: ID!){\n    post(id:$slug, idType:SLUG){\n      slug uri title excerpt content date modified\n      categories{nodes{slug name}}\n      tags{nodes{slug name}}\n      author{node{slug name}}\n      featuredImage{node{sourceUrl altText mediaDetails{width height}}}\n      seo{title metaDesc canonical opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl altText mediaDetails{width height}} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n    }\n  }`
     const data = await fetchGraphQL<any>(query, { slug })
     return data?.post ? mapPost(data.post) : undefined
   } catch (e) {
@@ -127,7 +127,7 @@ export async function getPostBySlug(slug: string): Promise<Post | undefined> {
 
 export async function getPageBySlug(slug: string): Promise<Page | undefined> {
   try {
-    const query = `query PageBySlug($slug: ID!){\n    page(id:$slug, idType:URI){\n      slug uri title excerpt content\n      seo{title metaDesc canonical robots opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n    }\n  }`
+    const query = `query PageBySlug($slug: ID!){\n    page(id:$slug, idType:URI){\n      slug uri title content\n      seo{title metaDesc canonical opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n    }\n  }`
     const data = await fetchGraphQL<any>(query, { slug })
     const node = data?.page
     return node
@@ -135,7 +135,6 @@ export async function getPageBySlug(slug: string): Promise<Page | undefined> {
           slug: node.slug,
           uri: node.uri ?? '',
           title: node.title,
-          excerpt: node.excerpt ?? '',
           content: node.content ?? '',
           seo: node.seo ?? undefined,
         }
@@ -148,7 +147,7 @@ export async function getPageBySlug(slug: string): Promise<Page | undefined> {
 
 export async function getCategoryBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   try {
-    const query = `query Category($slug: ID!, $first: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name uri\n      seo{title metaDesc canonical robots opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n      posts(first:$first){nodes{slug uri title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl altText mediaDetails{width height}}}}}\n    }\n  }`
+    const query = `query Category($slug: ID!, $first: Int!){\n    category(id:$slug, idType:SLUG){\n      slug name uri\n      seo{title metaDesc canonical opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n      posts(first:$first){nodes{slug uri title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl altText mediaDetails{width height}}}}}\n    }\n  }`
     const variables = { slug, first: perPage * page }
     const data = await fetchGraphQL<any>(query, variables)
     const start = (page - 1) * perPage
@@ -179,7 +178,7 @@ export async function getCategoryBySlug(slug: string, { page = 1, perPage = 10 }
 
 export async function getTagBySlug(slug: string, { page = 1, perPage = 10 }: { page?: number; perPage?: number }) {
   try {
-    const query = `query Tag($slug: ID!, $first: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name uri\n      seo{title metaDesc canonical robots opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n      posts(first:$first){nodes{slug uri title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl altText mediaDetails{width height}}}}}\n    }\n  }`
+    const query = `query Tag($slug: ID!, $first: Int!){\n    tag(id:$slug, idType:SLUG){\n      slug name uri\n      seo{title metaDesc canonical opengraphType opengraphTitle opengraphDescription opengraphImage{sourceUrl} twitterTitle twitterDescription twitterImage{sourceUrl} breadcrumbs{text url} schema{raw}}\n      posts(first:$first){nodes{slug uri title excerpt content date modified categories{nodes{slug name}} tags{nodes{slug name}} author{node{slug name}} featuredImage{node{sourceUrl altText mediaDetails{width height}}}}}\n    }\n  }`
     const variables = { slug, first: perPage * page }
     const data = await fetchGraphQL<any>(query, variables)
     const start = (page - 1) * perPage


### PR DESCRIPTION
## Summary
- avoid querying fields not supported by the WordPress GraphQL schema
- handle pages without excerpts when building SEO data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive setup)
- `npm run build` (fails: Failed to fetch font `Playfair Display`.)

------
https://chatgpt.com/codex/tasks/task_e_68aecea7435c83328f5cee8454b804a8