### PR TITLE
fix seo head

### DIFF
--- a/components/SeoHead.tsx
+++ b/components/SeoHead.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Head from 'next/head';
 
 export default function SeoHead({ data }: { data: ReturnType<typeof import('../lib/seo').normalizeSeo> }) {


### PR DESCRIPTION
## Summary
- mark SeoHead as a client component so meta tags render correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: required interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aed687d4bc8332bed190d91305188e