### PR TITLE
Centralize SEO head handling in layout

### DIFF
--- a/app/categorie/[slug]/page.tsx
+++ b/app/categorie/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
 import { getCategoryBySlug, getCategories, type Post } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -30,7 +30,7 @@ export default async function CategoryPage({ params }: Props) {
 
     return (
       <>
-        <SeoHead data={seoData} />
+        <Seo data={seoData} />
         <div>
         <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: category.name }]} />
         <h1 className="text-3xl font-bold mb-6">{category.name}</h1>

--- a/app/confidentialitate/page.tsx
+++ b/app/confidentialitate/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import { getPageBySlug } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -16,7 +16,7 @@ export default async function PrivacyPage() {
   })
   return (
     <>
-      <SeoHead data={seoData} />
+      <Seo data={seoData} />
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-4">{page?.title || 'Politica de confidențialitate'}</h1>
         <ProseContent html={page?.content || '<p>Aceasta este politica noastră de confidențialitate.</p>'} />

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import { getPageBySlug } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -16,7 +16,7 @@ export default async function ContactPage() {
   })
   return (
     <>
-      <SeoHead data={seoData} />
+      <Seo data={seoData} />
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-4">{page?.title || 'Contact'}</h1>
         <ProseContent html={page?.content || "<p>Ne poți scrie la <a href='mailto:contact@example.com'>contact@example.com</a>.</p>"} />

--- a/app/despre/page.tsx
+++ b/app/despre/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import { getPageBySlug } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -16,7 +16,7 @@ export default async function AboutPage() {
   })
   return (
     <>
-      <SeoHead data={seoData} />
+      <Seo data={seoData} />
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-4">{page?.title || 'Despre noi'}</h1>
         <ProseContent html={page?.content || '<p>Suntem un site de știri fictiv.</p>'} />

--- a/app/eticheta/[slug]/page.tsx
+++ b/app/eticheta/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import ArticleCard from '@/components/ArticleCard'
 import Breadcrumb from '@/components/Breadcrumb'
 import { getTagBySlug, fixtures, type Post } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -29,7 +29,7 @@ export default async function TagPage({ params }: Props) {
 
     return (
       <>
-        <SeoHead data={seoData} />
+        <Seo data={seoData} />
         <div>
         <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: `Etichetă: ${tag.name}` }]} />
         <h1 className="text-3xl font-bold mb-6">Etichetă: {tag.name}</h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { siteUrl } from '@/lib/utils'
 import AdsenseSlot from '@/components/AdsenseSlot'
 import { Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import SeoHead from '@/components/SeoHead'
+import { SeoProvider } from '@/components/SeoProvider'
 import { normalizeSeo } from '@/lib/seo'
 import { Inter, Playfair_Display } from 'next/font/google'
 
@@ -38,7 +38,6 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   })
   return (
     <html lang="ro" className={`${inter.variable} ${playfair.variable}`}>
-      <SeoHead data={seoData} />
       <head>
         <meta name="google-adsense-account" content="ca-pub-9593023557482879" />
         <script
@@ -55,108 +54,110 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
         />
       </head>
       <body className="flex min-h-screen flex-col bg-white text-black">
-        <header className="sticky top-0 z-50 border-b bg-white">
-          <AdsenseSlot className="w-full min-h-[90px] border-b" />
-          <div className="container mx-auto flex items-center justify-between gap-4 px-4 py-4">
-            <Link
-              href="/"
-              className="text-3xl font-serif font-bold text-accent"
-            >
-              Green News România
-            </Link>
-            <nav className="hidden flex-1 justify-center gap-6 text-sm md:flex">
-              {catError ? (
-                <span className="text-red-500">Eroare la categoriile</span>
-              ) : (
-                categories.map((c) => (
-                  <Link
-                    key={c.slug}
-                    href={`/categorie/${c.slug}`}
-                    className="hover:text-accent"
-                  >
-                    {c.name}
-                  </Link>
-                ))
-              )}
-            </nav>
-            <Button variant="ghost" size="icon" asChild>
-              <Link href="/cautare" aria-label="Căutare">
-                <Search className="h-5 w-5" />
+        <SeoProvider defaultData={seoData}>
+          <header className="sticky top-0 z-50 border-b bg-white">
+            <AdsenseSlot className="w-full min-h-[90px] border-b" />
+            <div className="container mx-auto flex items-center justify-between gap-4 px-4 py-4">
+              <Link
+                href="/"
+                className="text-3xl font-serif font-bold text-accent"
+              >
+                Green News România
               </Link>
-            </Button>
-          </div>
-        </header>
-        <main className="container mx-auto flex-1 px-4 py-8">{children}</main>
-        <footer className="mt-12 bg-gray-50">
-          <AdsenseSlot className="w-full min-h-[90px] border-b" />
-          <div className="container mx-auto grid gap-8 px-4 py-12 text-sm md:grid-cols-3">
-            <div>
-              <h3 className="mb-2 font-serif font-semibold">Despre</h3>
-              <p className="text-gray-600">
-                Green News România este o publicație dedicată știrilor despre
-                mediu și sustenabilitate.
-              </p>
-            </div>
-            <div>
-              <h3 className="mb-2 font-serif font-semibold">Link-uri rapide</h3>
-              <ul className="space-y-2">
+              <nav className="hidden flex-1 justify-center gap-6 text-sm md:flex">
                 {catError ? (
-                  <li className="text-red-500">Eroare la categoriile</li>
+                  <span className="text-red-500">Eroare la categoriile</span>
                 ) : (
                   categories.map((c) => (
-                    <li key={c.slug}>
-                      <Link
-                        href={`/categorie/${c.slug}`}
-                        className="hover:text-accent"
-                      >
-                        {c.name}
-                      </Link>
-                    </li>
+                    <Link
+                      key={c.slug}
+                      href={`/categorie/${c.slug}`}
+                      className="hover:text-accent"
+                    >
+                      {c.name}
+                    </Link>
                   ))
                 )}
-                <li>
-                  <Link href="/contact" className="hover:text-accent">
-                    Contact
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/publicitate" className="hover:text-accent">
-                    Publicitate
-                  </Link>
-                </li>
-              </ul>
+              </nav>
+              <Button variant="ghost" size="icon" asChild>
+                <Link href="/cautare" aria-label="Căutare">
+                  <Search className="h-5 w-5" />
+                </Link>
+              </Button>
             </div>
-            <div>
-              <h3 className="mb-2 font-serif font-semibold">Social</h3>
-              <ul className="space-y-2">
-                <li>
-                  <a href="#" className="hover:text-accent">
-                    Facebook
-                  </a>
-                </li>
-                <li>
-                  <a href="#" className="hover:text-accent">
-                    Instagram
-                  </a>
-                </li>
-                <li>
-                  <a href="#" className="hover:text-accent">
-                    LinkedIn
-                  </a>
-                </li>
-                <li>
-                  <a href="#" className="hover:text-accent">
-                    YouTube
-                  </a>
-                </li>
-              </ul>
+          </header>
+          <main className="container mx-auto flex-1 px-4 py-8">{children}</main>
+          <footer className="mt-12 bg-gray-50">
+            <AdsenseSlot className="w-full min-h-[90px] border-b" />
+            <div className="container mx-auto grid gap-8 px-4 py-12 text-sm md:grid-cols-3">
+              <div>
+                <h3 className="mb-2 font-serif font-semibold">Despre</h3>
+                <p className="text-gray-600">
+                  Green News România este o publicație dedicată știrilor despre
+                  mediu și sustenabilitate.
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-2 font-serif font-semibold">Link-uri rapide</h3>
+                <ul className="space-y-2">
+                  {catError ? (
+                    <li className="text-red-500">Eroare la categoriile</li>
+                  ) : (
+                    categories.map((c) => (
+                      <li key={c.slug}>
+                        <Link
+                          href={`/categorie/${c.slug}`}
+                          className="hover:text-accent"
+                        >
+                          {c.name}
+                        </Link>
+                      </li>
+                    ))
+                  )}
+                  <li>
+                    <Link href="/contact" className="hover:text-accent">
+                      Contact
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/publicitate" className="hover:text-accent">
+                      Publicitate
+                    </Link>
+                  </li>
+                </ul>
+              </div>
+              <div>
+                <h3 className="mb-2 font-serif font-semibold">Social</h3>
+                <ul className="space-y-2">
+                  <li>
+                    <a href="#" className="hover:text-accent">
+                      Facebook
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-accent">
+                      Instagram
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-accent">
+                      LinkedIn
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" className="hover:text-accent">
+                      YouTube
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
-          </div>
-          <div className="border-t py-4 text-center text-xs text-gray-500">
-            © {new Date().getFullYear()} Green News România. Toate drepturile
-            rezervate.
-          </div>
-        </footer>
+            <div className="border-t py-4 text-center text-xs text-gray-500">
+              © {new Date().getFullYear()} Green News România. Toate drepturile
+              rezervate.
+            </div>
+          </footer>
+        </SeoProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import SidebarPopular from '@/components/SidebarPopular'
 import AdsenseSlot from '@/components/AdsenseSlot'
 import FeaturedArticle from '@/components/FeaturedArticle'
 import { getPosts, getFeaturedPost, getPageBySlug } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -28,7 +28,7 @@ export default async function HomePage() {
     })
     return (
       <>
-        <SeoHead data={seoData} />
+        <Seo data={seoData} />
         <div className="grid gap-8 lg:grid-cols-[2fr,1fr]">
         <div className="space-y-8">
           {featured && <FeaturedArticle article={featured} />}

--- a/app/publicitate/page.tsx
+++ b/app/publicitate/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import { getPageBySlug } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -16,7 +16,7 @@ export default async function AdsPage() {
   })
   return (
     <>
-      <SeoHead data={seoData} />
+      <Seo data={seoData} />
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-4">{page?.title || 'Publicitate'}</h1>
         <ProseContent html={page?.content || '<p>Pentru spații publicitare, contactați-ne.</p>'} />

--- a/app/stiri/[slug]/page.tsx
+++ b/app/stiri/[slug]/page.tsx
@@ -6,7 +6,7 @@ import SidebarPopular from '@/components/SidebarPopular'
 import ArticleCard from '@/components/ArticleCard'
 import Image from 'next/image'
 import { getPostBySlug, getPosts } from '@/lib/wp'
-import SeoHead from '@/components/SeoHead'
+import Seo from '@/components/Seo'
 import { normalizeSeo } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -37,7 +37,7 @@ export default async function ArticlePage({ params }: Props) {
 
     return (
       <>
-        <SeoHead data={seoData} />
+        <Seo data={seoData} />
         <div className="mx-auto max-w-7xl">
           <Breadcrumb items={[{ label: 'Acasă', href: '/' }, { label: article.title }]} />
         <div className="lg:flex lg:gap-8">

--- a/components/Seo.tsx
+++ b/components/Seo.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { useEffect } from 'react';
+import { useSeo } from './SeoProvider';
+import { normalizeSeo } from '@/lib/seo';
+
+type SeoData = ReturnType<typeof normalizeSeo>;
+
+export default function Seo({ data }: { data: SeoData }) {
+  const { setData } = useSeo();
+  useEffect(() => {
+    setData(data);
+  }, [data, setData]);
+  return null;
+}

--- a/components/SeoProvider.tsx
+++ b/components/SeoProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+import { createContext, useContext, useState, ReactNode } from 'react';
+import SeoHead from './SeoHead';
+import { normalizeSeo } from '@/lib/seo';
+
+type SeoData = ReturnType<typeof normalizeSeo>;
+
+type SeoContextType = {
+  data: SeoData;
+  setData: (data: SeoData) => void;
+};
+
+const SeoContext = createContext<SeoContextType | undefined>(undefined);
+
+export function SeoProvider({ children, defaultData }: { children: ReactNode; defaultData: SeoData }) {
+  const [data, setData] = useState<SeoData>(defaultData);
+  return (
+    <SeoContext.Provider value={{ data, setData }}>
+      <SeoHead data={data} />
+      {children}
+    </SeoContext.Provider>
+  );
+}
+
+export function useSeo() {
+  const ctx = useContext(SeoContext);
+  if (!ctx) throw new Error('useSeo must be used within SeoProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- Centralize SEO rendering via new `SeoProvider` and `Seo` components
- Replace per-page `SeoHead` usage with context-based updates
- Wrap layout content with provider to render a single `SeoHead`

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run build` *(fails: failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_68aed88c594c8332a69c3047543b1c33