### PR TITLE
Add fallback SEO metadata for homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,8 +10,8 @@ export async function generateMetadata() {
   const homepage = await getPageBySlug('acasa').catch(() => undefined)
   const seoData = normalizeSeo({
     seo: homepage?.seo,
-    wpTitle: homepage?.title,
-    wpExcerpt: homepage?.excerpt ?? '',
+    wpTitle: homepage?.title ?? 'Green News România',
+    wpExcerpt: homepage?.excerpt ?? 'Portal de știri din România',
     url: '/',
     siteName: 'Green News România',
     siteUrl,


### PR DESCRIPTION
## Summary
- ensure homepage always has title and description metadata when WordPress content is missing

## Testing
- `npm test` *(fails: tsx not found)*
- `npm install` *(fails: 403 Forbidden for @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68aee1c4b9c88332aec3d8ecd0faffae