### PR TITLE
Refactor SEO fragments per parent type

### DIFF
--- a/README_SEO.md
+++ b/README_SEO.md
@@ -4,14 +4,14 @@ This project pulls Yoast SEO data from WordPress via WPGraphQL.
 
 ## Usage
 
-1. Queries in `lib/wp.ts` include a reusable `SeoFragment` to request SEO fields for posts, pages, categories, tags and authors.
+1. Queries in `lib/wp.ts` use type‑specific fragments like `SeoFieldsOnPost`, `SeoFieldsOnPage`, `SeoFieldsOnCategory`, `SeoFieldsOnTag` and `SeoFieldsOnUser` to request SEO fields.
 2. `normalizeSeo` in `lib/seo.ts` merges WordPress data with fallbacks and fixes URLs.
 3. `seoToMetadata` converts the normalized object into Next.js `Metadata` used by `generateMetadata` in each route.
 4. The `Seo` component renders JSON-LD and pagination `<link>` tags.
 
 ## Adding SEO to new routes
 
-- Fetch the `seo` field using `SeoFragment`.
+- Fetch the `seo` field using the appropriate `SeoFieldsOn*` fragment.
 - In the route, call `normalizeSeo` with content title/excerpt, url and site info.
 - Export `generateMetadata` returning `seoToMetadata`.
 - Render `<Seo jsonLd={...} />` with the JSON‑LD for the page.


### PR DESCRIPTION
## Summary
- replace `SeoFragment` on `SEO` with parent-type fragments (`SeoFieldsOnPost`, `SeoFieldsOnPage`, `SeoFieldsOnCategory`, `SeoFieldsOnTag`, `SeoFieldsOnUser`)
- update all WPGraphQL queries to use new fragments
- document new fragments in `README_SEO.md`

## Testing
- `curl https://cms.green-news.ro/wp/graphql -H 'Content-Type: application/json' -d '{"query":"query { post(id: 1, idType: DATABASE_ID) { seo { title } } }"}'` *(failed: CONNECT tunnel failed, response 403)*
- `npm run lint` *(failed: prompted for ESLint configuration)*
- `npm test` *(failed: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeec74c7a483328b4a0fde58627eeb