### PR TITLE
feat: centralize seo head component

### DIFF
--- a/app/confidentialitate/page.tsx
+++ b/app/confidentialitate/page.tsx
@@ -1,10 +1,18 @@
 import ProseContent from '@/components/ProseContent'
+import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
 export default async function PrivacyPage() {
   const page = await getPageBySlug('confidentialitate').catch(() => undefined)
+  const title =
+    page?.seo?.title ?? page?.title ?? 'Politica de confidențialitate'
+  const description =
+    page?.seo?.metaDesc ??
+    page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
+    'Politica de confidențialitate'
+  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',
@@ -16,10 +24,11 @@ export default async function PrivacyPage() {
     }
   return (
     <>
+      <SeoHead title={title} description={description} ogImage={ogImage} />
       {jsonLd && (
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) ?? '' }}
         />
       )}
       <div className="max-w-3xl mx-auto">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,10 +1,17 @@
 import ProseContent from '@/components/ProseContent'
+import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
 export default async function ContactPage() {
   const page = await getPageBySlug('contact').catch(() => undefined)
+  const title = page?.seo?.title ?? page?.title ?? 'Contact'
+  const description =
+    page?.seo?.metaDesc ??
+    page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
+    'Contact'
+  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',
@@ -15,10 +22,11 @@ export default async function ContactPage() {
     }
   return (
     <>
+      <SeoHead title={title} description={description} ogImage={ogImage} />
       {jsonLd && (
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) ?? '' }}
         />
       )}
       <div className="max-w-3xl mx-auto">

--- a/app/despre/page.tsx
+++ b/app/despre/page.tsx
@@ -1,10 +1,17 @@
 import ProseContent from '@/components/ProseContent'
+import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
 export default async function AboutPage() {
   const page = await getPageBySlug('despre').catch(() => undefined)
+  const title = page?.seo?.title ?? page?.title ?? 'Despre noi'
+  const description =
+    page?.seo?.metaDesc ??
+    page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
+    'Despre noi'
+  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',
@@ -15,10 +22,11 @@ export default async function AboutPage() {
     }
   return (
     <>
+      <SeoHead title={title} description={description} ogImage={ogImage} />
       {jsonLd && (
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) ?? '' }}
         />
       )}
       <div className="max-w-3xl mx-auto">

--- a/app/publicitate/page.tsx
+++ b/app/publicitate/page.tsx
@@ -1,10 +1,17 @@
 import ProseContent from '@/components/ProseContent'
+import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
 export default async function AdsPage() {
   const page = await getPageBySlug('publicitate').catch(() => undefined)
+  const title = page?.seo?.title ?? page?.title ?? 'Publicitate'
+  const description =
+    page?.seo?.metaDesc ??
+    page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
+    'Publicitate'
+  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',
@@ -15,10 +22,11 @@ export default async function AdsPage() {
     }
   return (
     <>
+      <SeoHead title={title} description={description} ogImage={ogImage} />
       {jsonLd && (
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: jsonLdScript(jsonLd) ?? '' }}
         />
       )}
       <div className="max-w-3xl mx-auto">

--- a/components/SeoHead.tsx
+++ b/components/SeoHead.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import Head from 'next/head'
+
+interface SeoHeadProps {
+  title?: string
+  description?: string
+  ogImage?: string
+}
+
+export default function SeoHead({ title, description, ogImage }: SeoHeadProps) {
+  return (
+    <Head>
+      <title>{title ?? 'Default Title'}</title>
+      <meta name="description" content={description ?? ''} />
+      {ogImage && <meta property="og:image" content={ogImage} />}
+    </Head>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add reusable `SeoHead` component to consolidate meta tag handling
- update static pages to use `SeoHead` with safe fallbacks for SEO data

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aef32d38908332bdedd01c526b6fea