### PR TITLE
fix: remove WordPress path from SEO URLs

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -60,7 +60,10 @@ function absoluteUrl(raw?: string | null, siteUrl?: string) {
   try {
     const base = new URL(siteUrl).origin;
     const url = raw.startsWith('http') ? new URL(raw) : new URL(raw, base);
-    return new URL(url.pathname + url.search + url.hash, base).toString();
+    let path = url.pathname + url.search + url.hash;
+    // Remove WordPress subdirectory (e.g. "/wp/") from generated URLs
+    path = path.replace(/^\/wp(\/|$)/, '/');
+    return new URL(path, base).toString();
   } catch {
     return raw.startsWith('/') ? `${siteUrl}${raw}` : raw;
   }

--- a/test/seo.test.ts
+++ b/test/seo.test.ts
@@ -18,3 +18,15 @@ test('seoToMetadata maps basic fields', () => {
   assert.equal(meta.description, 'Desc');
   assert.equal(meta.openGraph?.images?.[0].url, 'https://example.com/img.jpg');
 });
+
+test('normalizeSeo strips /wp prefix from URLs', () => {
+  const seo = normalizeSeo({
+    seo: {
+      canonical: 'https://cms.example.com/wp/sample',
+      opengraphUrl: 'https://cms.example.com/wp/sample',
+    },
+    siteUrl: 'https://example.com',
+  });
+  assert.equal(seo.canonical, 'https://example.com/sample');
+  assert.equal(seo.og.url, 'https://example.com/sample');
+});


### PR DESCRIPTION
## Summary
- strip `/wp` segment when normalizing SEO URLs
- cover URL normalization with unit tests

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefd0de5e48332895c233a4b404ebf