### PR TITLE
Rewrite CMS image host

### DIFF
--- a/app/confidentialitate/page.tsx
+++ b/app/confidentialitate/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import SeoHead from '@/components/SeoHead'
-import { getPageBySlug } from '@/lib/wp'
+import { getPageBySlug, rewriteCmsHost } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -12,7 +12,8 @@ export default async function PrivacyPage() {
     page?.seo?.metaDesc ??
     page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
     'Politica de confidențialitate'
-  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
+  const ogImage =
+    rewriteCmsHost(page?.seo?.opengraphImage?.sourceUrl) || undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import SeoHead from '@/components/SeoHead'
-import { getPageBySlug } from '@/lib/wp'
+import { getPageBySlug, rewriteCmsHost } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -11,7 +11,8 @@ export default async function ContactPage() {
     page?.seo?.metaDesc ??
     page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
     'Contact'
-  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
+  const ogImage =
+    rewriteCmsHost(page?.seo?.opengraphImage?.sourceUrl) || undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',

--- a/app/despre/page.tsx
+++ b/app/despre/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import SeoHead from '@/components/SeoHead'
-import { getPageBySlug } from '@/lib/wp'
+import { getPageBySlug, rewriteCmsHost } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -11,7 +11,8 @@ export default async function AboutPage() {
     page?.seo?.metaDesc ??
     page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
     'Despre noi'
-  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
+  const ogImage =
+    rewriteCmsHost(page?.seo?.opengraphImage?.sourceUrl) || undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',

--- a/app/publicitate/page.tsx
+++ b/app/publicitate/page.tsx
@@ -1,6 +1,6 @@
 import ProseContent from '@/components/ProseContent'
 import SeoHead from '@/components/SeoHead'
-import { getPageBySlug } from '@/lib/wp'
+import { getPageBySlug, rewriteCmsHost } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
 
@@ -11,7 +11,8 @@ export default async function AdsPage() {
     page?.seo?.metaDesc ??
     page?.excerpt?.replace(/<[^>]*>?/gm, '') ??
     'Publicitate'
-  const ogImage = page?.seo?.opengraphImage?.sourceUrl ?? undefined
+  const ogImage =
+    rewriteCmsHost(page?.seo?.opengraphImage?.sourceUrl) || undefined
   const jsonLd =
     page?.seo?.schema?.raw ?? {
       '@context': 'https://schema.org',

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,3 +1,5 @@
+import { rewriteCmsHost } from './wp'
+
 export type WPSeo = {
   title?: string | null;
   metaDesc?: string | null;
@@ -91,9 +93,11 @@ export function normalizeSeo(input: {
   ].filter(Boolean) as string[];
   const robots = robotsArr.length > 0 ? robotsArr.join(', ') : undefined;
 
-  const rawOg = seo?.opengraphImage?.sourceUrl ?? undefined;
+  const ogSource = seo?.opengraphImage?.sourceUrl;
+  const twSource = seo?.twitterImage?.sourceUrl ?? ogSource;
+  const rawOg = rewriteCmsHost(ogSource) || undefined;
   const ogImage = absoluteUrl(rawOg, siteUrl);
-  const rawTw = seo?.twitterImage?.sourceUrl ?? rawOg;
+  const rawTw = rewriteCmsHost(twSource) || undefined;
   const twImage = absoluteUrl(rawTw, siteUrl);
   const ogUrl = absoluteUrl(seo?.opengraphUrl ?? canonical, siteUrl);
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,11 +18,6 @@ const nextConfig = {
         hostname: 'green-news.ro',
         pathname: '/**',
       },
-      {
-        protocol: 'https',
-        hostname: 'cms.green-news.ro',
-        pathname: '/**',
-      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- add `rewriteCmsHost` helper to swap `cms.green-news.ro` with `green-news.ro`
- normalize post and page data, content HTML, and SEO image fields via new helper
- drop `cms.green-news.ro` from image remotePatterns and update pages to use rewritten SEO image URLs

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run build` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68af01585fc08332afb80227816fa801