### PR TITLE
feat: convert cached images to webp and fix SEO user query

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "tailwind-merge": "^2.2.1",
     "lucide-react": "^0.302.0",
     "class-variance-authority": "^0.7.0",
-    "@radix-ui/react-slot": "^1.0.2"
+    "@radix-ui/react-slot": "^1.0.2",
+    "sharp": "^0.33.1"
   },
   "devDependencies": {
     "typescript": "^5.2.2",


### PR DESCRIPTION
## Summary
- convert downloaded CMS images to WebP when caching
- adjust SEO fragment for users to match available GraphQL fields
- add sharp dependency

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68af10a95b748332933b8ed679e5d87f