### PR TITLE
Resize cached images with sharp

### DIFF
--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -47,7 +47,10 @@ async function cacheImage(url: string): Promise<string> {
       const res = await fetch(url)
       if (res.ok) {
         const buf = Buffer.from(await res.arrayBuffer())
-        await sharp(buf).webp().toFile(webpPath)
+        await sharp(buf)
+          .resize({ width: 1200, withoutEnlargement: true })
+          .webp({ quality: 80 })
+          .toFile(webpPath)
       }
     }
     return `/img/${webpName}`


### PR DESCRIPTION
## Summary
- resize cached CMS images to max width 1200px
- convert cached images to WebP at quality 80

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af145a4a908332815165d0dddc59e4