### PR TITLE
feat: replace header text with webp logo

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import Link from 'next/link'
+import Image from 'next/image'
 import { ReactNode } from 'react'
 import { getCategories } from '@/lib/wp'
 import { siteUrl } from '@/lib/utils'
@@ -50,7 +51,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
               '@type': 'Organization',
               name: 'Green News România',
               url: siteUrl,
-              logo: `${siteUrl}/logo.png`,
+              logo: `${siteUrl}/logo.webp`,
             }),
           }}
         />
@@ -58,11 +59,15 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       <body className="flex min-h-screen flex-col bg-white text-black">
           <header className="sticky top-0 z-50 border-b bg-white">
             <div className="container mx-auto flex items-center justify-between gap-4 px-4 py-4">
-              <Link
-                href="/"
-                className="text-3xl font-serif font-bold text-accent"
-              >
-                Green News România
+              <Link href="/" className="flex items-center">
+                <Image
+                  src="/logo.webp"
+                  alt="Green News România"
+                  width={120}
+                  height={65}
+                  className="h-8 w-auto"
+                  priority
+                />
               </Link>
               <nav className="hidden flex-1 justify-center gap-6 text-sm md:flex">
                 {catError ? (

--- a/app/stiri/[slug]/page.tsx
+++ b/app/stiri/[slug]/page.tsx
@@ -64,7 +64,7 @@ export default async function ArticlePage({ params }: Props) {
           name: 'Green News România',
           logo: {
             '@type': 'ImageObject',
-            url: `${siteUrl}/logo.png`,
+            url: `${siteUrl}/logo.webp`,
           },
         },
         mainEntityOfPage: seoData.canonical,


### PR DESCRIPTION
## Summary
- add webp version of site logo and drop png
- shrink header logo display for better fit
- point structured data to new webp asset
- remove webp logo asset from version control

## Testing
- `npm test`
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_68af1db8038c8332942aba32d584500e