### PR TITLE
feat: generate responsive images

### DIFF
--- a/app/stiri/[slug]/page.tsx
+++ b/app/stiri/[slug]/page.tsx
@@ -4,7 +4,7 @@ import ShareBar from '@/components/ShareBar'
 import AdsenseSlot from '@/components/AdsenseSlot'
 import SidebarPopular from '@/components/SidebarPopular'
 import ArticleCard from '@/components/ArticleCard'
-import Image from 'next/image'
+import ResponsiveImage from '@/components/ResponsiveImage'
 import { getPostBySlug, getPosts } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
@@ -88,12 +88,14 @@ export default async function ArticlePage({ params }: Props) {
               {article.title}
             </h1>
             {article.image && (
-              <Image
+              <ResponsiveImage
                 src={article.image}
                 alt={article.title}
                 width={1200}
                 height={600}
                 className="mb-6 w-full rounded-xl object-cover"
+                widths={[480, 800, 1200]}
+                sizes="100vw"
               />
             )}
             <ProseContent html={article.content} />

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -1,17 +1,19 @@
 import Link from 'next/link'
-import Image from 'next/image'
+import ResponsiveImage from './ResponsiveImage'
 import type { Post } from '@/lib/wp'
 
 export default function ArticleCard({ article }: { article: Post }) {
   return (
     <article className="overflow-hidden rounded-lg bg-white shadow-sm transition-shadow hover:shadow-md">
       <Link href={`/stiri/${article.slug}`}>
-        <Image
+        <ResponsiveImage
           src={article.image}
           alt={article.title}
           width={800}
           height={450}
           className="h-48 w-full object-cover"
+          widths={[480, 800]}
+          sizes="(max-width: 768px) 100vw, 33vw"
         />
       </Link>
       <div className="space-y-2 p-4">

--- a/components/FeaturedArticle.tsx
+++ b/components/FeaturedArticle.tsx
@@ -1,17 +1,19 @@
 import Link from 'next/link'
-import Image from 'next/image'
+import ResponsiveImage from './ResponsiveImage'
 import type { Post } from '@/lib/wp'
 
 export default function FeaturedArticle({ article }: { article: Post }) {
   return (
     <article className="space-y-4">
       <Link href={`/stiri/${article.slug}`}>
-        <Image
+        <ResponsiveImage
           src={article.image}
           alt={article.title}
           width={1200}
           height={600}
           className="w-full rounded-xl object-cover shadow"
+          widths={[480, 800, 1200]}
+          sizes="(max-width: 768px) 100vw, 50vw"
         />
       </Link>
       <h2 className="text-4xl font-serif font-bold leading-tight">

--- a/components/ResponsiveImage.tsx
+++ b/components/ResponsiveImage.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+interface ResponsiveImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  widths?: number[]
+  sizes?: string
+}
+
+const DEFAULT_WIDTHS = [480, 800, 1200]
+
+export default function ResponsiveImage({
+  src = '',
+  alt = '',
+  widths = DEFAULT_WIDTHS,
+  sizes = '100vw',
+  ...rest
+}: ResponsiveImageProps) {
+  const isExternal = src.startsWith('http')
+  if (isExternal) {
+    return <img src={src} alt={alt} {...rest} />
+  }
+
+  const dotIndex = src.lastIndexOf('.')
+  const ext = src.substring(dotIndex)
+  const base = src.substring(0, dotIndex)
+  const srcSet = widths.map((w) => `${base}-${w}${ext} ${w}w`).join(', ')
+  const largest = Math.max(...widths)
+
+  return (
+    <img
+      src={`${base}-${largest}${ext}`}
+      srcSet={srcSet}
+      sizes={sizes}
+      alt={alt}
+      {...rest}
+    />
+  )
+}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run generate-images && next build",
     "start": "npx serve out",
     "lint": "next lint",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "tsx test/seo.test.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "generate-images": "tsx scripts/generate-images.ts"
   },
   "dependencies": {
     "next": "^14.0.0",

--- a/scripts/generate-images.ts
+++ b/scripts/generate-images.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import sharp from 'sharp'
+
+const SIZES = [480, 800, 1200]
+const INPUT_DIR = path.join(process.cwd(), 'public', 'img')
+
+async function generate() {
+  const files = fs.readdirSync(INPUT_DIR)
+  for (const file of files) {
+    const filePath = path.join(INPUT_DIR, file)
+    if (!fs.statSync(filePath).isFile()) continue
+    const ext = path.extname(file)
+    const name = path.basename(file, ext)
+    for (const size of SIZES) {
+      const output = path.join(INPUT_DIR, `${name}-${size}${ext}`)
+      await sharp(filePath)
+        .resize({ width: size, withoutEnlargement: true })
+        .toFile(output)
+    }
+  }
+}
+
+generate().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add `ResponsiveImage` component to serve local images with `srcset` and responsive sizing
- generate multiple image widths via Sharp and ensure build runs the generator
- use responsive images in article cards and posts for better viewport optimization

## Testing
- `npm run generate-images` *(fails: Cannot find module 'sharp')*
- `npm run build` *(fails: Cannot find module 'sharp')*
- `npm test` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68af28f538bc8332a6c7e8cab1bdbec4