### PR TITLE
Handle unsupported image formats in generator

### DIFF
--- a/scripts/generate-images.ts
+++ b/scripts/generate-images.ts
@@ -4,19 +4,28 @@ import sharp from 'sharp'
 
 const SIZES = [480, 800, 1200]
 const INPUT_DIR = path.join(process.cwd(), 'public', 'img')
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp'])
 
 async function generate() {
   const files = fs.readdirSync(INPUT_DIR)
   for (const file of files) {
     const filePath = path.join(INPUT_DIR, file)
     if (!fs.statSync(filePath).isFile()) continue
-    const ext = path.extname(file)
+    const ext = path.extname(file).toLowerCase()
+    if (!SUPPORTED_EXTENSIONS.has(ext)) {
+      console.warn(`Skipping unsupported file type: ${file}`)
+      continue
+    }
     const name = path.basename(file, ext)
     for (const size of SIZES) {
       const output = path.join(INPUT_DIR, `${name}-${size}${ext}`)
-      await sharp(filePath)
-        .resize({ width: size, withoutEnlargement: true })
-        .toFile(output)
+      try {
+        await sharp(filePath)
+          .resize({ width: size, withoutEnlargement: true })
+          .toFile(output)
+      } catch (err) {
+        console.warn(`Failed to process ${file}:`, err)
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- skip unsupported files when generating responsive images
- handle per-file resize errors gracefully

## Testing
- `npm run generate-images` *(fails: Cannot find module 'sharp')*
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68af319bae648332b67698ef90b85568