### PR TITLE
feat: centralize cache control

### DIFF
--- a/app/cautare/page.tsx
+++ b/app/cautare/page.tsx
@@ -2,6 +2,9 @@ import ArticleCard from '@/components/ArticleCard'
 import { searchPosts } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_TTL } from '@/lib/cache'
+
+export const revalidate = CACHE_TTL
 
 export default async function SearchPage() {
   const term = ''

--- a/app/confidentialitate/page.tsx
+++ b/app/confidentialitate/page.tsx
@@ -3,6 +3,9 @@ import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_TTL } from '@/lib/cache'
+
+export const revalidate = CACHE_TTL
 
 export default async function PrivacyPage() {
   const page = await getPageBySlug('confidentialitate').catch(() => undefined)

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -3,6 +3,9 @@ import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_TTL } from '@/lib/cache'
+
+export const revalidate = CACHE_TTL
 
 export default async function ContactPage() {
   const page = await getPageBySlug('contact').catch(() => undefined)

--- a/app/despre/page.tsx
+++ b/app/despre/page.tsx
@@ -3,6 +3,9 @@ import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_TTL } from '@/lib/cache'
+
+export const revalidate = CACHE_TTL
 
 export default async function AboutPage() {
   const page = await getPageBySlug('despre').catch(() => undefined)

--- a/app/news-sitemap.xml/route.ts
+++ b/app/news-sitemap.xml/route.ts
@@ -1,5 +1,6 @@
 import { getPosts } from '@/lib/wp'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_CONTROL_HEADER } from '@/lib/cache'
 
 export const dynamic = 'force-static'
 
@@ -19,6 +20,7 @@ export async function GET() {
     return new Response(xml, {
       headers: {
         'Content-Type': 'application/xml',
+        'Cache-Control': CACHE_CONTROL_HEADER,
       },
     })
   } catch (e) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,9 @@ import FeaturedArticle from '@/components/FeaturedArticle'
 import { getPosts, getFeaturedPost, getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_TTL } from '@/lib/cache'
+
+export const revalidate = CACHE_TTL
 
 export default async function HomePage() {
   const page = 1

--- a/app/publicitate/page.tsx
+++ b/app/publicitate/page.tsx
@@ -3,6 +3,9 @@ import SeoHead from '@/components/SeoHead'
 import { getPageBySlug } from '@/lib/wp'
 import { normalizeSeo, seoToMetadata, jsonLdScript } from '@/lib/seo'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_TTL } from '@/lib/cache'
+
+export const revalidate = CACHE_TTL
 
 export default async function AdsPage() {
   const page = await getPageBySlug('publicitate').catch(() => undefined)

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,3 +1,5 @@
+import { CACHE_CONTROL_HEADER } from '@/lib/cache'
+
 export const dynamic = 'force-static'
 
 export async function GET() {
@@ -9,6 +11,7 @@ export async function GET() {
   return new Response(content, {
     headers: {
       'Content-Type': 'text/plain',
+      'Cache-Control': CACHE_CONTROL_HEADER,
     },
   })
 }

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,5 +1,6 @@
 import { getPosts } from '@/lib/wp'
 import { siteUrl } from '@/lib/utils'
+import { CACHE_CONTROL_HEADER } from '@/lib/cache'
 
 export const dynamic = 'force-static'
 
@@ -16,6 +17,7 @@ export async function GET() {
     return new Response(xml, {
       headers: {
         'Content-Type': 'application/xml',
+        'Cache-Control': CACHE_CONTROL_HEADER,
       },
     })
   } catch (e) {

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,2 @@
+export const CACHE_TTL = 60 * 60; // 1 hour
+export const CACHE_CONTROL_HEADER = `public, max-age=0, s-maxage=${CACHE_TTL}, stale-while-revalidate=${CACHE_TTL}`;

--- a/lib/wp.ts
+++ b/lib/wp.ts
@@ -6,6 +6,7 @@ import authorsFixture from './fixtures/authors.json'
 import categoriesFixture from './fixtures/categories.json'
 import postsFixture from './fixtures/posts.json'
 import type { WPSeo } from './seo'
+import { CACHE_TTL } from './cache'
 
 export interface Term { slug: string; name: string; uri?: string; seo?: WPSeo | null }
 export interface Author { slug: string; name: string }
@@ -150,7 +151,8 @@ async function fetchGraphQL<T>(query: string, variables: any): Promise<T> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, variables }),
-    next: { revalidate: 60 },
+    cache: 'force-cache',
+    next: { revalidate: CACHE_TTL },
   })
   if (!res.ok) {
     console.error('GraphQL fetch error', res.status)


### PR DESCRIPTION
## Summary
- introduce shared cache TTL and header helpers
- apply cache headers to sitemap and robots routes
- standardize page revalidation using shared TTL and improve GraphQL fetch caching

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist - run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68af3358b528833280890d9c9d0c4f68